### PR TITLE
Remove race condition in keyup event handler

### DIFF
--- a/src/Acts/CamdramBundle/Resources/public/javascripts/app/autocomplete.js
+++ b/src/Acts/CamdramBundle/Resources/public/javascripts/app/autocomplete.js
@@ -26,6 +26,13 @@ $(function() {
             Camdram.autocomplete.suggest(this);
         e.preventDefault();
         return false;
+    }).keydown(function(e) {
+        if(e.keyCode == 13)
+        {
+            e.preventDefault();
+            return false;
+        }
+        return true;
     }).on('paste', function() {
             Camdram.autocomplete.suggest(this);
     });


### PR DESCRIPTION
Fix bug #119. I've only checked this by injecting it into an open page, as I don't want to set up an entire camdram deployment for this small bug.
