### PR TITLE
Change getRank date format to fix autocomplete order, fixes #129

### DIFF
--- a/src/Acts/CamdramBundle/Entity/Person.php
+++ b/src/Acts/CamdramBundle/Entity/Person.php
@@ -299,7 +299,7 @@ class Person implements SearchableInterface
             }
         }
         if (!$latest) return 0;
-        else return $latest->format('U');
+        else return $latest->format('Ymd');
     }
 
     public function isIndexable()

--- a/src/Acts/CamdramBundle/Entity/Show.php
+++ b/src/Acts/CamdramBundle/Entity/Show.php
@@ -984,7 +984,7 @@ class Show implements SearchableInterface, OwnableInterface
     public function getRank()
     {
         if ($this->getStartAt()) {
-            return $this->getStartAt()->format('U');
+            return $this->getStartAt()->format('Ymd');
         } else {
             return 0;
         }


### PR DESCRIPTION
This fixes the issue in the autocomplete dropdown box, and also on the search results page.
As far as I can tell https://github.com/camdram/sphinx-realtime-bundle/blob/master/Transformer/ModelToSphinxAutoTransformer.php#L66 is not used in the ranking process.
According to my /etc/sphinx/sphinx.conf sphinx stores this rant as a uint, which would explain the error.
