### PR TITLE
Cookie law

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -47,7 +47,7 @@
                 hideprivacysettingstab: true
             },
             strings: {
-                notificationTitleImplicit: 'Camdram uses cookies to ensure you get the best exprience. By continuing to use our site, you agree to our <a href="{{ path('acts_camdram_privacy') }}">privacy policy</a>.'
+                notificationTitleImplicit: 'Camdram uses <a href="{{ path('acts_camdram_privacy') }}#cookies">cookies</a> to ensure you get the best experience. By continuing to use our site, you agree to our <a href="{{ path('acts_camdram_privacy') }}#privacy">privacy policy</a>.'
             }
         });
         // ]]>
@@ -108,3 +108,4 @@
         </script>
     </body>
 </html>
+

--- a/src/Acts/CamdramBundle/Resources/views/Static/privacy.html.twig
+++ b/src/Acts/CamdramBundle/Resources/views/Static/privacy.html.twig
@@ -5,7 +5,8 @@
 {% block body %}
 <div class="row">
     <div class="twelve columns">
-        <h2>Privacy Policy</h2>
+        <div class="row">
+        <h2 id="privacy">Privacy Policy</h2>
 
         <p>This page describes what data camdram.net collects about you when you
         use the website. The general rule is that we try not to be evil;
@@ -40,6 +41,30 @@
 
         <li>We will provide any information to authorities if required to by
         law.</li></ul><br />
+        </div>
+        <div class="row">
+        <h2 id="cookies">Cookies</h2>
+        <p>To find out about what cookies are, take a look at these websites.</p>
+        <ul>
+            <li><a href="http://www.bbc.co.uk/privacy/cookies/">www.bbc.co.uk</a></li>
+            <li><a href="http://ico.org.uk/for_the_public/topic_specific_guides/online/cookies">The Information Commissioner's Office.</a></li>
+        </ul>
+        <h3>How does Camdram use cookies?</h3>
+        <p>Some cookies are strictly necessary in order for users to navigate
+        around the site correctly. Camdram uses a cookie maintain information 
+        about the current session, allowing a user to be uniquely identified between
+        pages as they navigate around the site.</p>
+        <p>Functionality cookies allow Camdram to enable the 'remember me' functionality
+        for logging in to Camdram.</p>
+        <p>Camdram uses Google Analytics to improve performance of the site and
+        provide a better user experience. More information about what cookies are
+        used by Google Analytics can be found <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage">here</a>.
+        This is a tool commonly used on popular websites, including <a href="http://www.gov.uk">www.gov.uk</a> and
+        <a href="http://www.bbc.co.uk">the BBC</a>. Google provide a plug-in for
+        most common browsers allowing users to <a href="https://tools.google.com/dlpage/gaoptout">opt out</a>.
+        </p>
+        </div>
     </div>
 </div>
 {% endblock %}
+

--- a/src/Acts/CamdramBundle/Resources/views/layout.html.twig
+++ b/src/Acts/CamdramBundle/Resources/views/layout.html.twig
@@ -103,9 +103,10 @@
             <h5>About</h5>
             <a href="{{ path('acts_camdram_about') }}">About Camdram</a><br/>
             <a href="{{ path('acts_camdram_development') }}">Development</a><br/>
-            <a href="{{ path('acts_camdram_privacy') }}">Privacy policy</a><br/>
+            <a href="{{ path('acts_camdram_privacy') }}">Privacy & Cookies</a><br/>
             <a href="{{ path('acts_camdram_contact_us') }}">Contact Us</a><br/>
         </div>
     </div>
 
 {% endblock %}
+


### PR DESCRIPTION
Adds cookie law compliance. Implementation works on an implicit opt-in method, commonly used by many popular websites, by displaying a notice once to new visitors. As a side-effect this improves the prominence of Camdram's privacy policy. Fixes #56.
