### PR TITLE
Adding some more information to the help page to reflect that we now seem to need ruby-compass to build CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Use one of the following commands to install the necessary packages required to 
 
 ###Debian-based distributions, e.g. Ubuntu
 
-    $ sudo apt-get install git-core php5 php5-cli curl php5-curl php5-intl php5-sqlite php-apc php5-gd php5-json ruby ruby-compass
+    $ sudo apt-get install git-core php5 php5-cli curl php5-curl php5-intl php5-sqlite php-apc php5-gd php5-json ruby ruby-compass phpunit
 
 ###RPM-based distributions, e.g. Fedora
 


### PR DESCRIPTION
Adding some more information to the help page to reflect that we now seem to need ruby-compass to build CSS
