### PR TITLE
Add mailing list information

### DIFF
--- a/src/Acts/CamdramBundle/Resources/views/Show/application-edit.html.twig
+++ b/src/Acts/CamdramBundle/Resources/views/Show/application-edit.html.twig
@@ -15,6 +15,7 @@
         <div class="panel">
             <p>Use the form below to modify or extend your advert for core production team positions. The advert will be displayed
             until the deadline date.</p>
+            <p>The CUADC Directors' and Producers' Reps aim to send out the Directing and Producing mailing list with all the current directing and producing adverts on Camdram every Thursday during full term. For more information they can be contacted on <a href=mailto:director@cuadc.org> director@cuadc.org </a> and <a href=mailto:producer@cuadc.org> producer@cuadc.org </a> </p>
         </div>
 
         <form action="{{ path("put_show_application", {identifier: form.vars.value.show.slug, _method: 'put'}) }}" method="post">

--- a/src/Acts/CamdramBundle/Resources/views/Show/application-new.html.twig
+++ b/src/Acts/CamdramBundle/Resources/views/Show/application-new.html.twig
@@ -17,6 +17,7 @@
             and choreographers. The advert will be displayed until the deadline date.</p>
             <p>Advertisements for other positions (e.g. musicians) are advised to create either a technical team advert or audition using the link above for now
             (we have plans to overhaul the vacancies system eventually).</p>
+            <p>The CUADC Directors' and Producers' Reps aim to send out the Directing and Producing mailing list with all the current directing and producing adverts on Camdram every Thursday during full term. For more information they can be contacted on <a href=mailto:director@cuadc.org> director@cuadc.org </a> and <a href=mailto:producer@cuadc.org> producer@cuadc.org </a> </p>
         </div>
 
         <form action="{{ path("post_show_application", {identifier: show.slug}) }}" method="post">

--- a/src/Acts/CamdramBundle/Resources/views/Show/auditions-edit.html.twig
+++ b/src/Acts/CamdramBundle/Resources/views/Show/auditions-edit.html.twig
@@ -15,6 +15,7 @@
         <div class="panel">
             <p>Use the form below modify or add auditions for your show.</p>
             <p>You can add one or more audition sessions and/or leave contact details for people to get in touch about auditioning.</p>
+        	<p>The CUADC Actors' Reps aim to send out the Actors' mailing list with all the current auditions on Camdram every Tuesday and Friday during full term. For more information they can be contacted on <a href=mailto:actor@cuadc.org> actor@cuadc.org </a> </p>
         </div>
 
         <form action="{{ path("put_show_auditions", {identifier: form.vars.value.slug, _method: 'put'}) }}" method="post">

--- a/src/Acts/CamdramBundle/Resources/views/Show/techie-advert-edit.html.twig
+++ b/src/Acts/CamdramBundle/Resources/views/Show/techie-advert-edit.html.twig
@@ -27,6 +27,7 @@
             <p>If you simply want to renew or extend the advert simply check over the information and click 'Modify/Renew' below.
                 By default, the advert will be displayed for another 10 days from today. If you would like your advert to include
                 a specific deadline, please check the box below and enter a date and time.</p>
+            <p>The CUADC Technical Director and Designers' Rep aim to send out the Techies' and Designers' mailing lists with all the current technical and design vacancies on Camdram every Thursday during full term. For more information they can be contacted on <a href=mailto:td@cuadc.org> td@cuadc.org </a> or <a href=mailto:designer@cuadc.org> desginer@cuadc.org </a> </p>
         </div>
 
         <form action="{{ path("put_show_techie_advert", {identifier: form.vars.value.show.slug, _method: 'put'}) }}" method="post">

--- a/src/Acts/CamdramBundle/Resources/views/Show/techie-advert-new.html.twig
+++ b/src/Acts/CamdramBundle/Resources/views/Show/techie-advert-new.html.twig
@@ -16,6 +16,7 @@
             <p>Use the form below to create an advert for one or more technical positions on your show.</p>
             <p>By default, no deadline will be displayed, but adverts will expire after 10 days (you will receive an email notification in advance).
                 If you would like to advertise a specific deadline, please check the box below and enter a date and time.</p>
+            <p>The CUADC Technical Director and Designers' Rep aim to send out the Techies' and Designers' mailing lists with all the current technical and design vacancies on Camdram every Thursday during full term. For more information they can be contacted on <a href=mailto:td@cuadc.org> td@cuadc.org </a> or <a href=mailto:designer@cuadc.org> desginer@cuadc.org </a> </p>
         </div>
 
         <form action="{{ path("post_show_techie_advert", {identifier: form.vars.value.show.slug}) }}" method="post">


### PR DESCRIPTION
Added information about when the CUADC mailing lists are sent, along with contact email addresses. I'm currently having trouble getting my local version to display properly in my browser, so have only been able to try these changes by downloading and editing the html pages currently in use on the live version of V2.

Additionally, I think it would be best to wait until I've told all the relevant committee members I'm doing this (if only to check I've got the days right!), which I will do on Sunday.
