### PR TITLE
Tell travis we require sudo, to get VM, not docker image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+sudo: required
 
 php:
   - 5.4


### PR DESCRIPTION
Travis will now sometimes run projects in a docker image, which don't have root access for security reasons. We need sudo to install sphinx.