### PR TITLE
Fix society detection in authorisation email

### DIFF
--- a/src/Acts/CamdramBundle/Resources/views/Email/show_created.html.twig
+++ b/src/Acts/CamdramBundle/Resources/views/Email/show_created.html.twig
@@ -38,7 +38,7 @@ before authorizing.</p>
 <h3>Show details follow</h3	>
 
 <p>
-{% if show.society %}{{ show.society.name }}{% else %}{{ show.societyName }}{% endif %} presents<br>
+{% if show.society %}{{ show.society.name }} presents <br>{% endif %} 
 <b>{{ show.name }}</b><br>
 {% if show.author %} by {{ show.author }}<br> {% endif %}
 {% for p in show.performances %}

--- a/src/Acts/CamdramBundle/Resources/views/Email/show_details.txt.twig
+++ b/src/Acts/CamdramBundle/Resources/views/Email/show_details.txt.twig
@@ -1,4 +1,4 @@
-{% if show.society %}{{ show.society.name }}{% else %}{{ show.societyName }}{% endif %} presents
+{% if show.society %}{{ show.society.name }} presents {% endif %} 
 {{ show.name }}
 {% if show.author %}
     by {{ show.author }}


### PR DESCRIPTION
Only show “<society> presents” if there is a society present.