### PR TITLE
Make autocomplete use a person's last performance as index date

### DIFF
--- a/src/Acts/CamdramBundle/Entity/Person.php
+++ b/src/Acts/CamdramBundle/Entity/Person.php
@@ -530,8 +530,8 @@ class Person implements SearchableInterface
     {
         $latest = null;
         foreach ($this->getRoles() as $role) {
-            if ($role->getShow() && (!$latest || $role->getShow()->getStartAt() > $latest) && $role->getShow()->getStartAt()) {
-                $latest = $role->getShow()->getStartAt();
+            if ($role->getShow() && (!$latest || $role->getShow()->getEndAt() > $latest) && $role->getShow()->getEndAt()) {
+                $latest = $role->getShow()->getEndAt();
             }
         }
 


### PR DESCRIPTION
Currently the autocomplete function ranks people based on their index date, which is the latest starting date for all their shows. This is also used to display "(active until month year)". In cases where a show's last performance is sufficiently after the first (for example any show in a week that straddles the month boundary, or more extremely [a footlights tour](http://www.camdram.net/shows/the-footlights-international-tour-show-2015-love-handles) which has four months between first and last performances) people involved with the show are ranked lower than they perhaps should, and the 'active until' hint uses the wrong month.

I believe this change will have no effect other than those described above but I may be wrong. I have not been able to test it because I got an error setting up the mysql database.