### PR TITLE
General site notice banner

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -98,6 +98,7 @@
     <body>
         <div id="wrapper">
             {% if development_warning %}{% include '::dev-warning.html.twig' %}{% endif %}
+            {% if show_site_notice %}{% include '::site-notice.html.twig' %}{% endif %}
             {% block main %}{% endblock %}
         </div>
 

--- a/app/Resources/views/site-notice.html.twig
+++ b/app/Resources/views/site-notice.html.twig
@@ -1,0 +1,5 @@
+<div id="dev-info">
+    <h3><i class="fa fa-info"></i> Site Notice</h3>
+
+    <p>{{ site_notice_content }}</p>
+</div>

--- a/app/Resources/views/site-notice.html.twig
+++ b/app/Resources/views/site-notice.html.twig
@@ -1,4 +1,4 @@
-<div id="dev-info">
+<div id="site-notice">
     <h3><i class="fa fa-info"></i> Site Notice</h3>
 
     <p>{{ site_notice_content }}</p>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -28,6 +28,8 @@ twig:
         - 'ActsCamdramBundle:Form:fields.html.twig'
     globals:
         development_warning: %development_warning%
+        show_site_notice: %show_site_notice%
+        site_notice_content: %site_notice_content%
 
 # Assetic Configuration
 assetic:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -35,6 +35,6 @@ parameters:
     map_center: [52.20531,0.12179]
     development_warning: false
     show_site_notice: false
-    site_notice_content: "Camdram will be unavailable for scheduled maintenence from 00:00:00 on 1 January 1970 for approximately 1 hour."
+    site_notice_content: "Camdram will be unavailable for scheduled maintenance from 00:00:00 on 1 January 1970 for approximately 1 hour."
     search_namespace: camdram
     search_enable_listeners: false

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -34,5 +34,7 @@ parameters:
 
     map_center: [52.20531,0.12179]
     development_warning: false
+    show_site_notice: false
+    site_notice_content: "Camdram will be unavailable for scheduled maintenence from 00:00:00 on 1 January 1970 for approximately 1 hour."
     search_namespace: camdram
     search_enable_listeners: false

--- a/src/Acts/CamdramBundle/Resources/public/stylesheets/app/app.scss
+++ b/src/Acts/CamdramBundle/Resources/public/stylesheets/app/app.scss
@@ -313,3 +313,14 @@ $panel-font-color-alt: #000;
     color:#a00;
   }
 }
+
+#site-notice {
+  background:#dfdfff;
+  text-align:center;
+  padding:0.1em 1em;
+  font-size:0.9em;
+
+  h3 {
+    color:#000000;
+  }
+}


### PR DESCRIPTION
This pull request adds a large site notice banner, similar to the one used for the development environment warning but styled more as an informative alert.

My thoughts are that we could use this to communicate to users, such as to notify them of updates to our privacy policy or warn them of any planned maintenance downtime.