### PR TITLE
Updates CUADC mailing list info

### DIFF
--- a/src/Acts/CamdramBundle/Resources/views/Show/application-edit.html.twig
+++ b/src/Acts/CamdramBundle/Resources/views/Show/application-edit.html.twig
@@ -29,7 +29,7 @@
             <p>Use the form below to modify or extend your advert for core production team positions. The advert will be displayed
             until the deadline date.</p>
 
-            <p>The CUADC Directors' and Producers' Reps aim to send out the Directing and Producing mailing list with all the current directing and producing adverts on Camdram every Thursday during full term. For more information they can be contacted on <a href=mailto:director@cuadc.org> director@cuadc.org </a> and <a href=mailto:producer@cuadc.org> producer@cuadc.org </a> </p>
+            <p>The CUADC Directors' and Producers' Reps aim to send out the Production mailing list with all the current directing and producing adverts on Camdram once a week during full term. For more information they can be contacted on <a href=mailto:director@cuadc.org> director@cuadc.org </a> and <a href=mailto:producer@cuadc.org> producer@cuadc.org </a> </p>
         </div>
 
         <form action="{{ path("put_show_application", {identifier: form.vars.value.show.slug, _method: 'put'}) }}" method="post">

--- a/src/Acts/CamdramBundle/Resources/views/Show/application-new.html.twig
+++ b/src/Acts/CamdramBundle/Resources/views/Show/application-new.html.twig
@@ -17,7 +17,7 @@
             and choreographers. The advert will be displayed until the deadline date.</p>
             <p>Advertisements for other positions (e.g. musicians) are advised to create either a technical team advert or audition using the link above for now
             (we have plans to overhaul the vacancies system eventually).</p>
-            <p>The CUADC Directors' and Producers' Reps aim to send out the Directing and Producing mailing list with all the current directing and producing adverts on Camdram every Thursday during full term. For more information they can be contacted on <a href=mailto:director@cuadc.org> director@cuadc.org </a> and <a href=mailto:producer@cuadc.org> producer@cuadc.org </a> </p>
+            <p>The CUADC Directors' and Producers' Reps aim to send out the Production mailing list with all the current directing and producing adverts on Camdram once a week during full term. For more information they can be contacted on <a href=mailto:director@cuadc.org> director@cuadc.org </a> and <a href=mailto:producer@cuadc.org> producer@cuadc.org </a> </p>
         </div>
 
         <form action="{{ path("post_show_application", {identifier: show.slug}) }}" method="post">

--- a/src/Acts/CamdramBundle/Resources/views/Show/auditions-edit.html.twig
+++ b/src/Acts/CamdramBundle/Resources/views/Show/auditions-edit.html.twig
@@ -15,7 +15,7 @@
         <div class="panel">
             <p>Use the form below modify or add auditions for your show.</p>
             <p>You can add one or more audition sessions and/or leave contact details for people to get in touch about auditioning.</p>
-        	<p>The CUADC Actors' Reps aim to send out the Actors' mailing list with all the current auditions on Camdram every Tuesday and Friday during full term. For more information they can be contacted on <a href=mailto:actor@cuadc.org> actor@cuadc.org </a> </p>
+            <p>The CUADC Actors' Reps aim to send out the Actors' mailing list with all the current auditions on Camdram twice a week during full term. For more information they can be contacted on <a href=mailto:actor@cuadc.org> actor@cuadc.org </a> </p>
         </div>
 
         <form action="{{ path("put_show_auditions", {identifier: form.vars.value.slug, _method: 'put'}) }}" method="post">

--- a/src/Acts/CamdramBundle/Resources/views/Show/techie-advert-edit.html.twig
+++ b/src/Acts/CamdramBundle/Resources/views/Show/techie-advert-edit.html.twig
@@ -39,7 +39,7 @@
             <p>If you simply want to renew or extend the advert simply check over the information and click 'Modify/Renew' below.
                 By default, the advert will be displayed for another 10 days from today. If you would like your advert to include
                 a specific deadline, please check the box below and enter a date and time.</p>
-            <p>The CUADC Technical Director and Designers' Rep aim to send out the Techies' and Designers' mailing lists with all the current technical and design vacancies on Camdram every Thursday during full term. For more information they can be contacted on <a href=mailto:td@cuadc.org> td@cuadc.org </a> or <a href=mailto:designer@cuadc.org> desginer@cuadc.org </a> </p>
+            <p>The CUADC Technical Director, Technicians' Rep and Stage Managers' Rep aim to send out the Techies' mailing list with all the current technical vacancies on Camdram once a week during full term. The Designers' Rep aims to send the Designers' mailing list with all the current design vacancies on Camdram on a similar timetable. For more information they can be contacted on <a href=mailto:td@cuadc.org> td@cuadc.org </a>, <a href=mailto:technician@cuadc.org> technician@cuadc.org </a>, <a href=mailto:sm@cuadc.org> sm@cuadc.org </a> or <a href=mailto:designer@cuadc.org> desginer@cuadc.org </a> </p>
         </div>
 
         <form action="{{ path("put_show_techie_advert", {identifier: form.vars.value.show.slug, _method: 'put'}) }}" method="post">

--- a/src/Acts/CamdramBundle/Resources/views/Show/techie-advert-new.html.twig
+++ b/src/Acts/CamdramBundle/Resources/views/Show/techie-advert-new.html.twig
@@ -16,7 +16,7 @@
             <p>Use the form below to create an advert for one or more technical positions on your show.</p>
             <p>By default, no deadline will be displayed, but adverts will expire after 10 days (you will receive an email notification in advance).
                 If you would like to advertise a specific deadline, please check the box below and enter a date and time.</p>
-            <p>The CUADC Technical Director and Designers' Rep aim to send out the Techies' and Designers' mailing lists with all the current technical and design vacancies on Camdram every Thursday during full term. For more information they can be contacted on <a href=mailto:td@cuadc.org> td@cuadc.org </a> or <a href=mailto:designer@cuadc.org> desginer@cuadc.org </a> </p>
+            <p>The CUADC Technical Director, Technicians' Rep and Stage Managers' Rep aim to send out the Techies' mailing list with all the current technical vacancies on Camdram once a week during full term. The Designers' Rep aims to send the Designers' mailing list with all the current design vacancies on Camdram on a similar timetable. For more information they can be contacted on <a href=mailto:td@cuadc.org> td@cuadc.org </a>, <a href=mailto:technician@cuadc.org> technician@cuadc.org </a>, <a href=mailto:sm@cuadc.org> sm@cuadc.org </a> or <a href=mailto:designer@cuadc.org> desginer@cuadc.org </a> </p>
         </div>
 
         <form action="{{ path("post_show_techie_advert", {identifier: form.vars.value.show.slug}) }}" method="post">


### PR DESCRIPTION
Partially reverts 20f4b68 in that it removes the explicit day of week that the lists are sent on as this tends to vary from each new committee to committee. It also adds contact information from the SM Rep and Techies' Rep who are both now responsible along with the TD for the Techie's List.