### PR TITLE
Remove excludedate from acts_performances table

### DIFF
--- a/app/DoctrineMigrations/Version20180722122615.php
+++ b/app/DoctrineMigrations/Version20180722122615.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180722122615 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->addSql('INSERT INTO `acts_performances` (sid, venid, startdate, enddate, time, venue) SELECT sid, venid, startdate, excludedate - 1, time, venue FROM `acts_performances` WHERE startdate < excludedate AND excludedate <= enddate;');
+        $this->addSql('INSERT INTO `acts_performances` (sid, venid, startdate, enddate, time, venue) SELECT sid, venid, excludedate + 1, enddate, time, venue FROM `acts_performances` WHERE startdate <= excludedate AND excludedate < enddate;');
+        $this->addSql('DELETE FROM `acts_performances` WHERE startdate <= excludedate AND excludedate <= enddate;');
+
+        $this->addSql('ALTER TABLE acts_performances DROP excludedate');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE acts_performances ADD excludedate DATE DEFAULT NULL');
+    }
+}

--- a/app/Resources/views/performance/show.html.twig
+++ b/app/Resources/views/performance/show.html.twig
@@ -17,9 +17,6 @@
         {%- if date(p.startdate) != date(p.enddate) -%}
             {# Show the duration #}
              - {{ p.enddate|date('D jS F Y') }},
-            {% if (p.excludedate > p.startdate) and (p.excludedate < p.enddate) %}
-                (except {{ p.excludedate|date('jS') }})
-            {% endif %}
         {% endif %}
         {% if p.venue %}
             at {% if disable_links is defined -%}

--- a/app/Resources/views/performance/show.txt.twig
+++ b/app/Resources/views/performance/show.txt.twig
@@ -4,9 +4,6 @@
     {{- p.time|date('g:ia') }}, {{ p.startdate|date('D jS F Y') -}}
 {%- if date(p.startdate) != date(p.enddate) %}
  - {{ p.enddate|date('D jS F Y') }},
-{%- if (p.excludedate > p.startdate) and (p.excludedate < p.enddate) %}
- (except {{ p.excludedate|date('jS') }})
-{% endif %}
 {% endif %}
 {%- if p.venue %}
  at {{ p.venue.name }}

--- a/src/Acts/CamdramBundle/Controller/ShowController.php
+++ b/src/Acts/CamdramBundle/Controller/ShowController.php
@@ -30,16 +30,6 @@ class ShowController extends AbstractRestController
         return $this->getDoctrine()->getManager()->getRepository('ActsCamdramBundle:Show');
     }
 
-    protected function getEntity($identifier)
-    {
-        $show = parent::getEntity($identifier);
-        //In order to simplify the interface, phasing out the 'excluding' field in performance date ranges. The method
-        //below replaces any performance range with an 'excluding' field with two performance ranges.
-        $show->fixPerformanceExcludes();
-
-        return $show;
-    }
-
     protected function getForm($show = null, $method = 'POST')
     {
         if (is_null($show)) {

--- a/src/Acts/CamdramBundle/Entity/Performance.php
+++ b/src/Acts/CamdramBundle/Entity/Performance.php
@@ -62,15 +62,6 @@ class Performance
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="excludedate", type="date", nullable=true)
-     * @Serializer\Expose
-     * @Gedmo\Versioned
-     */
-    private $exclude_date;
-
-    /**
-     * @var \DateTime
-     *
      * @ORM\Column(name="time", type="time", nullable=false)
      * @Serializer\Expose
      * @Gedmo\Versioned
@@ -127,8 +118,6 @@ class Performance
     }
 
     /**
-<<<<<<< HEAD
-=======
      * Get show_id
      *
      * @return int
@@ -139,7 +128,6 @@ class Performance
     }
 
     /**
->>>>>>> master
      * Set start_date
      *
      * @param \DateTime $startDate
@@ -185,30 +173,6 @@ class Performance
     public function getEndDate()
     {
         return $this->end_date;
-    }
-
-    /**
-     * Set exclude_date
-     *
-     * @param \DateTime $excludeDate
-     *
-     * @return Performance
-     */
-    public function setExcludeDate($excludeDate)
-    {
-        $this->exclude_date = $excludeDate;
-
-        return $this;
-    }
-
-    /**
-     * Get exclude_date
-     *
-     * @return \DateTime
-     */
-    public function getExcludeDate()
-    {
-        return $this->exclude_date;
     }
 
     /**
@@ -325,36 +289,18 @@ class Performance
      * Generate a more useful view of the performance dates, making it easier
      * to render the diary page.
      *
-     * @return
+     * @return An array of diary entries (currently just one).
      */
     public function getDiaryEntries()
     {
         $entries = array();
         $entry = array();
 
-        if (($this->exclude_date > $this->start_date) &&
-            ($this->exclude_date < $this->end_date)) {
-            /* If there's a valid exclude date then they'll be two entries */
-            $entry['startdate'] = $this->start_date;
-            $entry['enddate'] = $this->exclude_date->modify('-1 day');
-            /* Dates are inclusive */
-            $entry['numdays'] = $entry['enddate']->diff($entry['startdate'])->d + 1;
+        $entry['startdate'] = $this->start_date;
+        $entry['enddate'] = $this->end_date;
+        $entry['numdays'] = $entry['enddate']->diff($entry['startdate'])->d + 1;
 
-            $entries[] = $entry;
-
-            $entry['startdate'] = $this->exclude_date->modify('+1 day');
-            $entry['enddate'] = $this->end_date;
-            $entry['numdays'] = $entry['enddate']->diff($entry['startdate'])->d + 1;
-
-            $entries[] = $entry;
-        } else {
-            /* Just one simple entry */
-            $entry['startdate'] = $this->start_date;
-            $entry['enddate'] = $this->end_date;
-            $entry['numdays'] = $entry['enddate']->diff($entry['startdate'])->d + 1;
-
-            $entries[] = $entry;
-        }
+        $entries[] = $entry;
 
         return $entries;
     }

--- a/src/Acts/CamdramBundle/Entity/PerformanceRepository.php
+++ b/src/Acts/CamdramBundle/Entity/PerformanceRepository.php
@@ -66,10 +66,6 @@ class PerformanceRepository extends EntityRepository
                 }
 
                 $count += $end_at->diff($start_at)->d + 1;
-                if ($p->getExcludeDate() && $p->getExcludeDate()->format('u') > 0
-                    && $p->getExcludeDate() > $start_at && $p->getExcludeDate() < $end_at) {
-                    $count--;
-                }
             }
         }
 

--- a/src/Acts/CamdramBundle/Entity/Show.php
+++ b/src/Acts/CamdramBundle/Entity/Show.php
@@ -866,30 +866,6 @@ class Show implements OwnableInterface
         return $this->end_at;
     }
 
-    public function fixPerformanceExcludes()
-    {
-        foreach ($this->getPerformances() as $performance) {
-            /** @var $performance \Acts\CamdramBundle\Entity\Performance */
-            if ($performance->getExcludeDate()) {
-                if ($performance->getStartDate() > $performance->getExcludeDate() || $performance->getEndDate() < $performance->getExcludeDate()) {
-                    $performance->setExcludeDate(null);
-                } else {
-                    $p2 = clone $performance;
-                    $start = clone $p2->getExcludeDate();
-                    $start->add(new \DateInterval('P1D'));
-                    $p2->setStartDate($start);
-                    $p2->setExcludeDate(null);
-                    $this->performances[] = $p2;
-
-                    $end = clone $performance->getExcludeDate();
-                    $end->sub(new \DateInterval('P1D'));
-                    $performance->setEndDate($end);
-                    $performance->setExcludeDate(null);
-                }
-            }
-        }
-    }
-
     public function getMultiVenue()
     {
         if ($this->multi_venue) {
@@ -1519,7 +1495,6 @@ class Show implements OwnableInterface
         foreach ($this->getPerformances() as $performance) {
             $current_day = clone $performance->getStartDate(); //ate'] . " " . $perf['time']);
             $end_day = $performance->getEndDate(); //ate'] . " " . $perf['time']);
-            $exclude = $performance->getExcludeDate();
             $time = $performance->getTime();
             if ($performance->getVenue() != null) {
                 $venue = $performance->getVenue()->getName();
@@ -1527,12 +1502,10 @@ class Show implements OwnableInterface
                 $venue = $performance->getOtherVenue();
             }
             while ($current_day <= $end_day) {
-                if ($current_day != $exclude) {
-                    $datetime = clone $current_day;
+                $datetime = clone $current_day;
 
-                    $datetime->setTime($time->format('G'), $time->format('i'), $time->format('s')); //  Eugh. PHP doesn't seem to give a better way
-                    array_push($ret, array('date' => $current_day, 'time' => $time, 'datetime' => $datetime, 'venue' => $venue));
-                }
+                $datetime->setTime($time->format('G'), $time->format('i'), $time->format('s')); //  Eugh. PHP doesn't seem to give a better way
+                array_push($ret, array('date' => $current_day, 'time' => $time, 'datetime' => $datetime, 'venue' => $venue));
                 $current_day = clone $current_day;
                 $current_day->modify('+1 day');
             }

--- a/src/Acts/CamdramBundle/Service/DiaryHelper.php
+++ b/src/Acts/CamdramBundle/Service/DiaryHelper.php
@@ -51,26 +51,10 @@ class DiaryHelper
             $event->setVenueLink($this->router->generate('get_venue', array('identifier' => $performance->getVenue()->getSlug())));
         }
 
-        if ($performance->getStartDate() < $performance->getExcludeDate() && $performance->getExcludeDate() < $performance->getEndDate()) {
-            $end1 = clone $performance->getExcludeDate();
-            $end1->modify('-1 day');
-            $start2 = clone $performance->getExcludeDate();
-            $start2->modify('+1 day');
+        $event->setStartDate($performance->getStartDate());
+        $event->setEndDate($performance->getEndDate());
 
-            $event2 = clone $event;
-            $event->setStartDate($performance->getStartDate());
-            $event->setEndDate($end1);
-            $event2->setStartDate($start2);
-            $event2->setEndDate($performance->getEndDate());
-            $event2->setUid($performance->getId().'_2@camdram.net');
-
-            return array($event, $event2);
-        } else {
-            $event->setStartDate($performance->getStartDate());
-            $event->setEndDate($performance->getEndDate());
-
-            return array($event);
-        }
+        return array($event);
     }
 
     /**

--- a/src/Acts/DiaryBundle/Diary/DiaryRow.php
+++ b/src/Acts/DiaryBundle/Diary/DiaryRow.php
@@ -119,30 +119,14 @@ class DiaryRow
             $item->setStartIndex($this->calculateIndex($event->getDate()));
             $this->addItem($item);
         } elseif ($event instanceof MultiDayEventInterface) {
-            if (($event->getStartDate() < $event->getExcludeDate()) &&
-                ($event->getExcludeDate() < $event->getEndDate())) {
-                $start_index = $this->calculateIndex($event->getStartDate());
-                $end_index = $this->calculateIndex($event->getExcludeDate());
-                $item->setStartIndex($start_index);
-                $item->setNumberOfDays($end_index - $start_index);
-                $this->addItem($item);
-
-                $item2 = clone $item;
-                $start_index = $this->calculateIndex($event->getExcludeDate());
-                $end_index = $this->calculateIndex($event->getEndDate());
-                $item2->setStartIndex($start_index + 1);
-                $item2->setNumberOfDays($end_index - $start_index);
-                $this->addItem($item2);
-            } else {
-                $start_index = $this->calculateIndex($event->getStartDate());
-                $end_index = $this->calculateIndex($event->getEndDate());
-                $numberOfDays = $end_index - $start_index + 1;
-                if ($numberOfDays > 0) {
-                    $item->setStartIndex($start_index);
-                    $item->setNumberOfDays($end_index - $start_index + 1);
-                    $this->addItem($item);
-                }
-            }
+           $start_index = $this->calculateIndex($event->getStartDate());
+           $end_index = $this->calculateIndex($event->getEndDate());
+           $numberOfDays = $end_index - $start_index + 1;
+           if ($numberOfDays > 0) {
+               $item->setStartIndex($start_index);
+               $item->setNumberOfDays($end_index - $start_index + 1);
+               $this->addItem($item);
+           }
         }
     }
 

--- a/src/Acts/DiaryBundle/Event/MultiDayEvent.php
+++ b/src/Acts/DiaryBundle/Event/MultiDayEvent.php
@@ -15,11 +15,6 @@ class MultiDayEvent extends AbstractEvent implements MultiDayEventInterface
     private $end_date;
 
     /**
-     * @var \DateTime
-     */
-    private $exclude_date;
-
-    /**
      * {@inheritdoc}
      */
     public function getStartDate()
@@ -53,23 +48,5 @@ class MultiDayEvent extends AbstractEvent implements MultiDayEventInterface
     public function setEndDate(\DateTime $end_date)
     {
         $this->end_date = $end_date;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getExcludeDate()
-    {
-        return $this->exclude_date;
-    }
-
-    /**
-     * Set a single date between the start and end dates on which the event does not take place
-     *
-     * @param \DateTime|null $exclude_date
-     */
-    public function setExcludeDate($exclude_date)
-    {
-        $this->exclude_date = $exclude_date;
     }
 }

--- a/src/Acts/DiaryBundle/Event/MultiDayEventInterface.php
+++ b/src/Acts/DiaryBundle/Event/MultiDayEventInterface.php
@@ -8,13 +8,6 @@ namespace Acts\DiaryBundle\Event;
 interface MultiDayEventInterface extends EventInterface
 {
     /**
-     * A single date within the range on which the event does not take place
-     *
-     * @return \DateTime|null
-     */
-    public function getExcludeDate();
-
-    /**
      * The first date on which the event takes place
      *
      * @return \DateTime

--- a/tests/DiaryBundle/Diary/DiaryRowTest.php
+++ b/tests/DiaryBundle/Diary/DiaryRowTest.php
@@ -88,25 +88,6 @@ class DiaryRowTest extends TestCase
         $this->assertEquals(2, $item->getNumberOfDays());
     }
 
-    public function testAddMultiDayEvent_ExcludeDate()
-    {
-        $event = new MultiDayEvent();
-        $event->setStartDate(new \DateTime('2014-02-03'));
-        $event->setExcludeDate(new \DateTime('2014-02-05'));
-        $event->setEndDate(new \DateTime('2014-02-10'));
-        $event->setStartTime(new \DateTime('14:00'));
-        $event->setEndTime(new \DateTime('15:00'));
-        $this->row->addEvent($event);
-
-        $items = $this->row->getItems();
-        $this->assertEquals(2, $items[2]->getStartIndex());
-        $this->assertEquals(3, $items[2]->getEndIndex());
-        $this->assertEquals(2, $items[2]->getNumberOfDays());
-        $this->assertEquals(5, $items[5]->getStartIndex());
-        $this->assertEquals(6, $items[5]->getEndIndex());
-        $this->assertEquals(2, $items[5]->getNumberOfDays());
-    }
-
     public function testCanAccept_WithinTimeThreshold()
     {
         $event = new SingleDayEvent();

--- a/tests/DiaryBundle/Event/MultiDayEventTest.php
+++ b/tests/DiaryBundle/Event/MultiDayEventTest.php
@@ -11,11 +11,9 @@ class MultiDayEventTest extends TestCase
     {
         $event = new MultiDayEvent();
         $event->setStartDate(new \DateTime('2014-02-01'));
-        $event->setExcludeDate(new \DateTime('2014-02-05'));
         $event->setEndDate(new \DateTime('2014-02-07'));
 
         $this->assertEquals('1 February 2014', $event->getStartDate()->format('j F Y'));
-        $this->assertEquals('5 February 2014', $event->getExcludeDate()->format('j F Y'));
         $this->assertEquals('7 February 2014', $event->getEndDate()->format('j F Y'));
     }
 }


### PR DESCRIPTION
I've already manually fixed the weird cases where a one-day performance was set to exclude itself. Everything else should work in the migration, but I'd appreciate someone else's eyes on it before I break the production database.