### PR TITLE
Remove unused affiliate field from Organisation model

### DIFF
--- a/app/DoctrineMigrations/Version20180824225230.php
+++ b/app/DoctrineMigrations/Version20180824225230.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180824225230 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE acts_societies DROP affiliate');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE acts_societies ADD affiliate tinyint(1) NOT NULL AFTER type');
+    }
+}

--- a/src/Acts/CamdramBundle/Entity/Organisation.php
+++ b/src/Acts/CamdramBundle/Entity/Organisation.php
@@ -104,14 +104,6 @@ abstract class Organisation implements OwnableInterface
     private $college;
 
     /**
-     * @var bool
-     *
-     * @ORM\Column(name="affiliate", type="boolean", nullable=false)
-     * @Gedmo\Versioned
-     */
-    private $affiliate = 0;
-
-    /**
      * @var string
      *
      * @ORM\Column(name="logourl", type="string", length=255, nullable=true)
@@ -191,30 +183,6 @@ abstract class Organisation implements OwnableInterface
     public function getCollege()
     {
         return $this->college;
-    }
-
-    /**
-     * Set affiliate
-     *
-     * @param bool $affiliate
-     *
-     * @return Society
-     */
-    public function setAffiliate($affiliate)
-    {
-        $this->affiliate = $affiliate;
-
-        return $this;
-    }
-
-    /**
-     * Get affiliate
-     *
-     * @return bool
-     */
-    public function getAffiliate()
-    {
-        return $this->affiliate;
     }
 
     /**


### PR DESCRIPTION
Migration to remove the unused `affiliate` field from the db. Also removes and depreciates the associated code in the Organisation model.