### PR TITLE
Multiple societies

### DIFF
--- a/app/DoctrineMigrations/Version20181203000730.php
+++ b/app/DoctrineMigrations/Version20181203000730.php
@@ -27,7 +27,7 @@ class Version20181203000730 extends AbstractMigration
 
         // Migrate
         $this->addSql('UPDATE acts_shows SET socs_list = "[]"');
-        $this->addSql('UPDATE acts_shows SET socs_list = CONCAT("[", JSON_QUOTE(society), "]") ' .
+        $this->addSql("UPDATE acts_shows SET socs_list = CONCAT('[\"', REPLACE(REPLACE(society, '\\\\', '\\\\\\\\'), '\\\"', '\\\\\"'), '\"]') " .
                       'WHERE socid IS NULL AND COALESCE(society, "") <> "";');
         $this->addSql('UPDATE acts_shows SET socs_list = CONCAT("[", socid, "]") WHERE socid IS NOT NULL;');
         $this->addSql('INSERT INTO acts_show_soc_link (show_id, society_id) SELECT id, socid FROM acts_shows WHERE socid IS NOT NULL');

--- a/app/DoctrineMigrations/Version20181203000730.php
+++ b/app/DoctrineMigrations/Version20181203000730.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20181203000730 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // New table and column
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE acts_show_soc_link (show_id INT NOT NULL, society_id INT NOT NULL, INDEX IDX_DCC3C2ED0C1FC64 (show_id), INDEX IDX_DCC3C2EE6389D24 (society_id), PRIMARY KEY(show_id, society_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE acts_show_soc_link ADD CONSTRAINT FK_DCC3C2ED0C1FC64 FOREIGN KEY (show_id) REFERENCES acts_shows (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE acts_show_soc_link ADD CONSTRAINT FK_DCC3C2EE6389D24 FOREIGN KEY (society_id) REFERENCES acts_societies (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE acts_shows DROP FOREIGN KEY FK_1A1A53FEAF648A81');
+        $this->addSql('DROP INDEX IDX_1A1A53FEAF648A81 ON acts_shows');
+        $this->addSql('ALTER TABLE acts_shows ADD socs_list TEXT NOT NULL');
+
+        // Migrate
+        $this->addSql('UPDATE acts_shows SET socs_list = "[]"');
+        $this->addSql('UPDATE acts_shows SET socs_list = CONCAT("[", JSON_QUOTE(society), "]") ' .
+                      'WHERE socid IS NULL AND COALESCE(society, "") <> "";');
+        $this->addSql('UPDATE acts_shows SET socs_list = CONCAT("[", socid, "]") WHERE socid IS NOT NULL;');
+        $this->addSql('INSERT INTO acts_show_soc_link (show_id, society_id) SELECT id, socid FROM acts_shows WHERE socid IS NOT NULL');
+
+        // Drop old columns
+        $this->addSql('ALTER TABLE acts_shows DROP socid, DROP society');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP TABLE acts_show_soc_link');
+        $this->addSql('ALTER TABLE acts_shows ADD socid INT DEFAULT NULL, ADD society VARCHAR(255) DEFAULT NULL COLLATE utf8mb4_unicode_ci, DROP socs_list');
+        $this->addSql('ALTER TABLE acts_shows ADD CONSTRAINT FK_1A1A53FEAF648A81 FOREIGN KEY (socid) REFERENCES acts_societies (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_1A1A53FEAF648A81 ON acts_shows (socid)');
+    }
+}

--- a/app/Resources/views/audition/rss.html.twig
+++ b/app/Resources/views/audition/rss.html.twig
@@ -1,11 +1,18 @@
-<p>{{ entity.show.name }}</p>
+<p>{{ entity.show.name }}
 
-{% if entity.show.society %}
-	- <a href="{{ path('get_society', {identifier: entity.show.society.slug}) }}">{{ entity.show.society.shortname ?: entity.show.society.name }}</a>
-{% elseif entity.show.societyname is not empty %}
-    - {{ entity.show.societyname }}
+{% for society in entity.show.prettysocdata %}
+{{- loop.index == 1 ? " – " -}}
+{%- if society.id is defined -%}
+    <a href="{{ path('get_society', {identifier: society.slug}) }}">{{ society.shortname ?: society.name }}</a>
+{%- else -%}
+    {{ society.name }}
 {% endif %}
-
+{%- if loop.revindex > 2 -%}
+    ,
+{% elseif loop.revindex == 2 %}
+    and
+{% endif -%}
+{% endfor %}</p>
 <p>{{ entity.show.audextra | camdram_markdown }}</p>
 
 <ul>

--- a/app/Resources/views/email/show_created.html.twig
+++ b/app/Resources/views/email/show_created.html.twig
@@ -37,19 +37,7 @@ before authorizing.</p>
 
 <h3>Show details follow</h3	>
 
-<p>
-{% if show.society %}{{ show.society.name }} presents <br>{% endif %} 
-<b>{{ show.name }}</b><br>
-{% if show.author %} by {{ show.author }}<br> {% endif %}
-{% for p in show.performances %}
-    {{ p.time|date('g:ia') }}, {{ p.startdate|date('D jS F Y') }}{% if date(p.startdate) != date(p.enddate) %} - {{ p.enddate|date('D jS F Y') }},{% endif %}
-    {%- if p.venue %} @ {{ p.venue.name|e }}
-    {%- elseif p.venuename is not empty %} @ {{ p.venuename }}
-    {%- else %} @ Venue to be confirmed{% endif %}
-    <br>
-{% endfor %}
-</p>
-
+{% include 'show/advert_header.html.twig' %}
 <p>
 	{{ show.description }}
 </p>

--- a/app/Resources/views/email/show_details.txt.twig
+++ b/app/Resources/views/email/show_details.txt.twig
@@ -1,13 +1,3 @@
-{% if show.society %}{{ show.society.name }} presents {% endif %} 
-{{ show.name }}
-{% if show.author %}
-    by {{ show.author }}
-{% endif %}
-{% for p in show.performances %}{% spaceless %}
-    {{ p.time|date('g:ia') }}, {{ p.startdate|date('D jS F Y') }}{% if date(p.startdate) != date(p.enddate) %} - {{ p.enddate|date('D jS F Y') }},{% endif %}
-    {%- if p.venue %} @ {{ p.venue.name|e }}
-    {%- elseif p.venuename is not empty %} @ {{ p.venuename }}
-    {%- else %} @ Venue to be confirmed{% endif %}
-{% endspaceless %}{% endfor %}
+{% include 'show/advert_header.txt.twig' %}
 
 {{ show.description }}

--- a/app/Resources/views/show/advert_header.html.twig
+++ b/app/Resources/views/show/advert_header.html.twig
@@ -3,11 +3,19 @@
  direct or produce. #}
 <h4><a href="{{ path('get_show',
     {identifier: show.slug}) }}">{{ show.name }}</a>
-{% if show.society %}
-    - <a href="{{ path('get_society', {identifier: show.society.slug}) }}">{{ show.society.shortname ?: show.society.name }}</a>
-{% elseif show.societyname is not empty %}
-    - {{ show.societyname }}
-{% endif %}
+    {% for society in show.prettysocdata %}
+        {{- loop.index == 1 ? " – " -}}
+        {%- if society.id is defined -%}
+            <a href="{{ path('get_society', {identifier: society.slug}) }}">{{ society.shortname ?: society.name }}</a>
+        {%- else -%}
+            {{ society.name }}
+        {%- endif -%}
+        {%- if loop.revindex > 2 -%}
+            ,
+        {% elseif loop.revindex == 2 %}
+            and
+        {% endif -%}
+    {% endfor %}
 </h4>
 <p>{% include 'performance/show.html.twig' with { 'performances' : show.performances} %}
 {% if show.weeks is not empty %}

--- a/app/Resources/views/show/advert_header.txt.twig
+++ b/app/Resources/views/show/advert_header.txt.twig
@@ -1,11 +1,16 @@
 {# A common template for displaying information of about a show in any kind
  of advert i.e. auditions, production team vancancies, and applications to
  direct or produce. #}
-{% if show.society %}
-    {{- show.society.shortname ?: show.society.name }} presents
-{% elseif show.societyname is not empty %}
-    {{- show.societyname }} presents
+{% for society in show.prettysocdata %}
+{%- if society.id is defined -%}
+{{ society.shortname ?: society.name }}
+{%- else -%}
+{{ society.name }}
+{%- endif -%}
+{%- if loop.revindex > 2 -%}, {% elseif loop.revindex == 2 %} and {% elseif loop.length == 1 %} presents...
+{% else %} present...
 {% endif %}
+{% endfor %}
 {{ show.name }}
 {% include 'performance/show.txt.twig' with {
     'performances' : show.performances} -%}

--- a/app/Resources/views/show/form.html.twig
+++ b/app/Resources/views/show/form.html.twig
@@ -29,12 +29,19 @@
 </div>
 
 <div class="form-large-row">
-    {{ form_label(form.society) }}
-    {{ form_widget(form.society) }}
-    {{ form_errors(form.society) }}
-    {% if form.society.vars.disabled %}
-    <p>Please <a href="{{ path('acts_camdram_contact_us') }}">contact us</a> if you would like to change this show's society</p>
-    {% endif %}
+    {{ form_label(form.societies) }}
+    <div>
+        <p>Registered societies will appear in the search pop-up, but you can also add societies that aren't registered with Camdram. Adding a registered society allows its admins to approve and edit your show.
+        {{ form_errors(form.societies) }}</p>
+        <div class="linked-societies" data-prototype="{% filter escape('html') %}{% include 'show/society-form.html.twig' with {society: form.societies.vars.prototype} %}{% endfilter %}">
+            {% for society in form.societies %}
+		{% include 'show/society-form.html.twig' with {society: society} %}
+            {% endfor %}
+        </div>
+        <ul class="inline-list right">
+           <li> <a href="#" class="add_link">Add society</a></li>
+        </ul>
+    </div>
 </div>
 
 {{ form_row(form.description) }}
@@ -107,6 +114,15 @@ $(function() {
     update_date_fields();
     $('.performances').entityCollection({
         initialiseRow: update_date_fields
+    });
+    $('.linked-societies').entityCollection({
+        initialiseRow: function(index, row) {
+            var input = $(row).find("input");
+            console.log(row);
+            input.addClass("autocomplete_input");
+            input.entitySearch({route: 'get_societies'});
+        },
+        min_items: 0
     });
 });
 </script>

--- a/app/Resources/views/show/form.html.twig
+++ b/app/Resources/views/show/form.html.twig
@@ -42,6 +42,7 @@
            <li> <a href="#" class="add_link">Add society</a></li>
         </ul>
     </div>
+    {% do form.societies.setRendered %}
 </div>
 
 {{ form_row(form.description) }}

--- a/app/Resources/views/show/show.html.twig
+++ b/app/Resources/views/show/show.html.twig
@@ -51,15 +51,24 @@
         </li>{%- endif -%}
     </ul>
 
-    {%- if show.society -%}
-        <p class="show-society" itemprop="organizer" itemscope="" itemtype="http://schema.org/TheaterGroup">
-                <a href="{{ path('get_society', {identifier: show.society.slug}) }}" itemprop="url"><span itemprop="name">{{ show.society.name }}</span></a> presents...
-        </p>
-    {% elseif show.societyname is not empty %}
-        <p class="show-society" itemprop="organizer" itemscope="" itemtype="http://schema.org/TheaterGroup">
-            <span itemprop="name" content="{{ show.societyname }}">{{ show.societyname }}</span> presents...
-        </p>
-    {% endif %}
+    {%- for soc in show.prettysocdata -%}
+        <span itemprop="organizer" itemscope="" itemtype="http://schema.org/TheaterGroup">
+        {%- if soc.id is defined -%}
+            <a href="{{ path('get_society', {identifier: soc.slug}) }}" itemprop="url"><span itemprop="name">{{ soc.name }}</span></a>
+        {%- else -%}
+            <span itemprop="name" content="{{ soc.name }}">{{ soc.name }}</span>
+        {%- endif -%}
+        </span>
+        {%- if loop.revindex > 2 -%}
+            ,
+        {% elseif loop.revindex == 2 %}
+            and
+        {% elseif loop.length == 1 %}
+            presents...
+        {%- else %}
+            present...
+        {%- endif -%}
+    {% endfor %}
 
     <h2 itemprop="workPerformed" itemscope="" itemtype="http://schema.org/CreativeWork">
         <span itemprop="name">{{ show.name }}</span>

--- a/app/Resources/views/show/society-form.html.twig
+++ b/app/Resources/views/show/society-form.html.twig
@@ -1,0 +1,10 @@
+<div class="form-medium-widget">
+    <menu style="display: flex; justify-content: space-around" class="fake-label">
+        <a href="#!" class="fa fa-fw remove_link fa-times" title="Remove this society"></a>
+        <a href="#!" class="fa fa-fw fa-long-arrow-up" title="Move this society up"></a>
+        <a href="#!" class="fa fa-fw fa-long-arrow-down" title="Move this society down"></a>
+    </menu>
+    {{ form_widget(society) }}
+    {{ form_errors(society)}}
+    {{ form_rest(society) }}
+</div>

--- a/app/Resources/views/show/society-form.html.twig
+++ b/app/Resources/views/show/society-form.html.twig
@@ -1,8 +1,8 @@
 <div class="form-medium-widget">
     <menu style="display: flex; justify-content: space-around" class="fake-label">
         <a href="#!" class="fa fa-fw remove_link fa-times" title="Remove this society"></a>
-        <a href="#!" class="fa fa-fw fa-long-arrow-up" title="Move this society up"></a>
-        <a href="#!" class="fa fa-fw fa-long-arrow-down" title="Move this society down"></a>
+        <a href="#!" data-entitycollection="moveup" class="fa fa-fw fa-long-arrow-up" title="Move this society up"></a>
+        <a href="#!" data-entitycollection="movedown" class="fa fa-fw fa-long-arrow-down" title="Move this society down"></a>
     </menu>
     {{ form_widget(society) }}
     {{ form_errors(society)}}

--- a/assets/js/camdram.js
+++ b/assets/js/camdram.js
@@ -232,19 +232,25 @@ import Bloodhound from 'typeahead.js'
             var $add_link = $(options.add_link_selector, $self.parent());
 
             var update_links = function() {
+                var uparrows = $('[data-entitycollection="moveup"]', $self);
+                var downarrows = $('[data-entitycollection="movedown"]', $self);
                 if ($('.remove_link', $self).length > options.min_items) {
-                    $('.remove_link', $self).show();
+                    $('.remove_link', $self).css('visibility', 'visible');
                 }
                 else {
-                    $('.remove_link', $self).hide();
+                    $('.remove_link', $self).css('visibility', 'hidden');
                 }
 
                 if ($('.remove_link', $self).length < options.max_items) {
-                    $add_link.show();
+                    $add_link.css('visibility', 'visible');
                 }
                 else {
-                    $add_link.hide();
+                    $add_link.css('visibility', 'hidden');
                 }
+                uparrows.not(':first').css('visibility', 'visible');
+                uparrows.first().css('visibility', 'hidden');
+                downarrows.not(':last').css('visibility', 'visible');
+                downarrows.last().css('visibility', 'hidden');
             }
 
             $add_link.click(function(e) {
@@ -254,15 +260,29 @@ import Bloodhound from 'typeahead.js'
                 $self.append($row);
                 fixHtml($row);
                 update_links();
-                options.initialiseRow.apply($row);
+                options.initialiseRow(index, $row);
                 index++;
-            })
+            });
 
-            $('.remove_link', $self).live('click', function(e) {
+            $self.on('click', '.remove_link', function(e) {
                 e.preventDefault();
                 $(this).parentsUntil($self).remove();
                 update_links();
-            })
+            });
+
+            var rowSwapper = function(e) {
+                e.preventDefault();
+                var action = this.getAttribute('data-entitycollection');
+                var $myRow = $(this).parentsUntil($self).last();
+                var myInput = $myRow.find("input[name]").get(0);
+                var otherInput = (action === 'moveup' ? $myRow.prev() : $myRow.next()
+                      ).find("input[name]").get(0);
+                var temp = myInput.value;
+                myInput.value = otherInput.value;
+                otherInput.value = temp;
+            }
+
+            $self.on('click', '[data-entitycollection]', rowSwapper);
 
             update_links();
             $self.children().each(options.initialiseRow);

--- a/assets/scss/forms.scss
+++ b/assets/scss/forms.scss
@@ -117,12 +117,12 @@ textarea {
   flex-flow: row wrap;
   align-items: center;
 
-  > label {
+  > label, > .fake-label {
     min-width: 7rem;
     padding: 0.4rem 0.7rem;
-  }
-  > label + * {
-    flex: 20em;
+    + * {
+      flex: 20em;
+    }
   }
 }
 

--- a/src/Acts/CamdramBundle/Controller/AbstractRestController.php
+++ b/src/Acts/CamdramBundle/Controller/AbstractRestController.php
@@ -125,7 +125,7 @@ abstract class AbstractRestController extends FOSRestController
                 $em->persist($form->getData());
                 $em->flush();
             } catch (\Elastica\Exception\ExceptionInterface $ex) {
-                $this->get('logger')->warning('Failed to add new entity to search index', ['type' => $this->type, 'id' => $entity->getId()]);
+                $this->get('logger')->warning('Failed to add new entity to search index', ['type' => $this->type]);
             }
             $this->get('camdram.security.acl.provider')->grantAccess($form->getData(), $this->getUser(), $this->getUser());
             $this->afterEditFormSubmitted($form, $form->getData()->getSlug());

--- a/src/Acts/CamdramBundle/Controller/ShowController.php
+++ b/src/Acts/CamdramBundle/Controller/ShowController.php
@@ -126,9 +126,8 @@ class ShowController extends AbstractRestController
         $admins = $this->get('camdram.security.acl.provider')->getOwners($show);
         $requested_admins = $em->getRepository('ActsCamdramSecurityBundle:User')->getRequestedShowAdmins($show);
         $pending_admins = $em->getRepository('ActsCamdramSecurityBundle:PendingAccess')->findByResource($show);
-        if ($show->getSociety()) {
-            $admins[] = $show->getSociety();
-        }
+        $admins = array_merge($admins, $show->getSocieties()->toArray());
+
         if ($show->getVenue()) {
             $admins[] = $show->getVenue();
         }

--- a/src/Acts/CamdramBundle/DataFixtures/ShowFixtures.php
+++ b/src/Acts/CamdramBundle/DataFixtures/ShowFixtures.php
@@ -178,9 +178,11 @@ class ShowFixtures extends Fixture implements DependentFixtureInterface
     private function allocateSociety(Show $show)
     {
         if (mt_rand(0, 3) == 0) {
-            $show->setOtherSociety('Random Society '.mt_rand(1, 100));
+            $show->setSocietiesDisplayList(json_encode(['Random Society '.mt_rand(1, 100)]));
         } else {
-            $show->setSociety($this->society_repo->findOneById($this->society_ids[mt_rand(0, count($this->society_ids) - 1)]));
+            $socId = $this->society_ids[mt_rand(0, count($this->society_ids) - 1)];
+            $show->setSocietiesDisplayList('['.$socId.']');
+            $show->getSocieties()->add($this->society_repo->findOneById($socId));
         }
     }
 

--- a/src/Acts/CamdramBundle/Entity/ApplicationRepository.php
+++ b/src/Acts/CamdramBundle/Entity/ApplicationRepository.php
@@ -65,8 +65,7 @@ class ApplicationRepository extends EntityRepository
     public function findLatestBySociety(Society $society, $limit, \DateTime $now)
     {
         $qb = $this->getLatestQuery($limit, $now);
-        $qb->andWhere(
-                    $qb->expr()->orX('s.society = :society', 'a.society = :society')
+        $qb->andWhere($qb->expr()->orX(':society MEMBER OF s.societies', 'a.society = :society')
             )->setParameter('society', $society);
 
         return $qb->getQuery()->getResult();

--- a/src/Acts/CamdramBundle/Entity/AuditionRepository.php
+++ b/src/Acts/CamdramBundle/Entity/AuditionRepository.php
@@ -90,14 +90,14 @@ class AuditionRepository extends EntityRepository
     public function findUpcomingBySociety(Society $society, $limit, \DateTime $now)
     {
         return $this->getUpcomingQuery($limit, $now)
-            ->leftJoin('s.society', 'y')->andWhere('y = :society')->setParameter('society', $society)
+            ->andWhere(':society MEMBER OF s.societies')->setParameter('society', $society)
             ->getQuery()->getResult();
     }
 
     public function findUpcomingNonScheduledBySociety(Society $society, $limit, \DateTime $now)
     {
         return $this->getUpcomingNonScheduledQuery($limit, $now)
-            ->leftJoin('s.society', 'y')->andWhere('y = :society')->setParameter('society', $society)
+            ->andWhere(':society MEMBER OF s.societies')->setParameter('society', $society)
             ->getQuery()->getResult();
     }
 

--- a/src/Acts/CamdramBundle/Entity/PerformanceRepository.php
+++ b/src/Acts/CamdramBundle/Entity/PerformanceRepository.php
@@ -95,7 +95,7 @@ class PerformanceRepository extends EntityRepository
             ->addSelect('s')
             ->addSelect('v')
             ->where('s.authorised = true')
-            ->andWhere('s.society = :society');
+            ->andWhere(':society MEMBER OF s.societies');
 
         if ($from) {
             $query = $query->andWhere('p.start_date > :from')->setParameter('from', $from);

--- a/src/Acts/CamdramBundle/Entity/Show.php
+++ b/src/Acts/CamdramBundle/Entity/Show.php
@@ -172,7 +172,7 @@ class Show implements OwnableInterface
      *
      * @var string
      *
-     * @ORM\Column(name="socs_list", type="string", nullable=true)
+     * @ORM\Column(name="socs_list", type="text", nullable=false)
      * @Gedmo\Versioned
      */
     private $societies_display_list = '';
@@ -831,6 +831,8 @@ class Show implements OwnableInterface
 
         $this->entry_expiry = new \DateTime();
         $this->timestamp    = new \DateTime();
+
+        $this->setSocietiesDisplayList('[]');
     }
 
     /**

--- a/src/Acts/CamdramBundle/Entity/Show.php
+++ b/src/Acts/CamdramBundle/Entity/Show.php
@@ -165,7 +165,7 @@ class Show implements OwnableInterface
      * A JSON representation of how the show's societies should be displayed,
      * for the purpose of storing unregistered societies and how they are
      * ordered with registered societies.
-     * NOT used for access control or anything outside the /shows/ page.
+     * NOT used for access control etc.
      * ["New Society", 12] might be rendered as
      *     New Society and Cambridge Footlights present...
      * assuming the Footlights have id 12.
@@ -489,12 +489,28 @@ class Show implements OwnableInterface
     }
 
     /**
+     * DEPRECATED and going away eventually. Returns the first society, if it
+     * is registered.
+     * @Api\Link(embed=true, name="society", route="get_society", params={"identifier": "object.getSocietyLegacy().getSlug()"})
+     */
+    public function getSocietyLegacy()
+    {
+        $data = $this->getPrettySocData();
+        if (empty($data) || is_array($data[0])) { return; }
+        return $data[0];
+    }
+
+    /**
      * DEPRECATED and going away eventually. Returns the first society name.
+     * Historically afaict this could differ from getSociety()->getName();
+     * as the other_society column has now been deleted, they now must be
+     * consistent.
      * @Serializer\VirtualProperty()
      * @Serializer\Type("string")
      * @Serializer\XmlElement(cdata=false)
+     * @Serializer\SerializedName("other_society")
      */
-    public function getOtherSociety()
+    public function getOtherSocietyLegacy()
     {
         $data = $this->getPrettySocData();
         return empty($data) ? NULL :
@@ -505,8 +521,9 @@ class Show implements OwnableInterface
      * The correct way to access societies in the API.
      * @Serializer\VirtualProperty()
      * @Serializer\XmlKeyValuePairs()
+     * @Serializer\SerializedName("societies")
      */
-    public function getAllSocieties()
+    public function getSocietiesForAPI()
     {
         $data = $this->getPrettySocData();
         return array_map(function($s) {

--- a/src/Acts/CamdramBundle/Entity/Show.php
+++ b/src/Acts/CamdramBundle/Entity/Show.php
@@ -489,6 +489,32 @@ class Show implements OwnableInterface
     }
 
     /**
+     * DEPRECATED and going away eventually. Returns the first society name.
+     * @Serializer\VirtualProperty()
+     * @Serializer\Type("string")
+     * @Serializer\XmlElement(cdata=false)
+     */
+    public function getOtherSociety()
+    {
+        $data = $this->getPrettySocData();
+        return empty($data) ? NULL :
+            (is_array($data[0]) ? $data[0]["name"] : $data[0]->getName());
+    }
+
+    /**
+     * The correct way to access societies in the API.
+     * @Serializer\VirtualProperty()
+     * @Serializer\XmlKeyValuePairs()
+     */
+    public function getAllSocieties()
+    {
+        $data = $this->getPrettySocData();
+        return array_map(function($s) {
+            return is_array($s) ? $s : ["id" => $s->getId(), "name" => $s->getName(), "slug" => $s->getSlug()];
+        }, $data);
+    }
+
+    /**
      * Set societies_display_list
      *
      * @param string $societiesList
@@ -504,7 +530,7 @@ class Show implements OwnableInterface
 
     /**
      * Gets all relevant data on societies ready for display to the user;
-     * returns an array of arrays [ "name" => "Some Small Soc" ] or Societies.
+     * returns an array of arrays [ "name" => "Some Small Soc" ] or of Societies.
      * Uses societies_display_list for ordering but gives priority to the info
      * in societies.
      */

--- a/src/Acts/CamdramBundle/Entity/ShowRepository.php
+++ b/src/Acts/CamdramBundle/Entity/ShowRepository.php
@@ -34,7 +34,7 @@ class ShowRepository extends EntityRepository
     {
         $qb = $this->createQueryBuilder('s')
             ->where('s.authorised = false')
-            ->andWhere('s.society = :society')
+            ->andWhere(':society MEMBER OF s.societies')
             ->setParameter('society', $society)
             ->join('s.performances', 'p');
 
@@ -197,7 +197,7 @@ class ShowRepository extends EntityRepository
             ->addSelect('s')
             ->addSelect('v')
             ->where('s.authorised = true')
-            ->andWhere('s.society = :society');
+            ->andWhere(':society MEMBER OF s.societies');
 
         if ($from) {
             $query = $query->andWhere('p.start_date > :from')->setParameter('from', $from);

--- a/src/Acts/CamdramBundle/Entity/Society.php
+++ b/src/Acts/CamdramBundle/Entity/Society.php
@@ -16,7 +16,7 @@ use Acts\CamdramApiBundle\Configuration\Annotation as Api;
 class Society extends Organisation
 {
     /**
-     * @ORM\OneToMany(targetEntity="Show", mappedBy="society")
+     * @ORM\ManyToMany(targetEntity="Show", mappedBy="society")
      * @Api\Link(route="get_society_shows", params={"identifier": "object.getSlug()"})
      */
     private $shows;

--- a/src/Acts/CamdramBundle/Entity/Society.php
+++ b/src/Acts/CamdramBundle/Entity/Society.php
@@ -16,7 +16,7 @@ use Acts\CamdramApiBundle\Configuration\Annotation as Api;
 class Society extends Organisation
 {
     /**
-     * @ORM\ManyToMany(targetEntity="Show", mappedBy="society")
+     * @ORM\ManyToMany(targetEntity="Show", mappedBy="societies")
      * @Api\Link(route="get_society_shows", params={"identifier": "object.getSlug()"})
      */
     private $shows;

--- a/src/Acts/CamdramBundle/Entity/TechieAdvertRepository.php
+++ b/src/Acts/CamdramBundle/Entity/TechieAdvertRepository.php
@@ -21,7 +21,7 @@ class TechieAdvertRepository extends EntityRepository
         $query = $qb->leftJoin('a.show', 's')
             ->where($qb->expr()->orX('a.expiry > :expiry', $qb->expr()->andX('a.expiry = :expiry', 'a.deadlineTime >= :time')))
             ->andWhere('s.authorised = true')
-            ->orderBy('a.expiry, s.name, s.society')
+            ->orderBy('a.expiry, s.name')
             ->setParameter('expiry', $date, \Doctrine\DBAL\Types\Type::DATE)
             ->setParameter('time', $date, \Doctrine\DBAL\Types\Type::TIME)
             ->getQuery();
@@ -50,7 +50,7 @@ class TechieAdvertRepository extends EntityRepository
     public function findLatestBySociety(Society $society, $limit, \DateTime $now)
     {
         return $this->getLatestQuery($limit, $now)
-            ->leftJoin('s.society', 'y')->andWhere('y = :society')->setParameter('society', $society)
+            ->andWhere(':society MEMBER OF s.societies')->setParameter('society', $society)
             ->getQuery()->getResult();
     }
 

--- a/src/Acts/CamdramBundle/EventListener/ShowListener.php
+++ b/src/Acts/CamdramBundle/EventListener/ShowListener.php
@@ -75,12 +75,20 @@ class ShowListener
     {
         $authorisationEmailSent = false;
 
-        if ($event->hasChangedField('society') && ! $show->getSocieties()->isEmpty()) {
-            if ($show->getAuthorised()) {
-                $this->moderationManager->notifySocietyChanged($show);
-            } else {
-                $this->moderationManager->autoApproveOrEmailModerators($show);
-                $authorisationEmailSent = true;
+        if ($event->hasChangedField('societies_display_list') && ! $show->getSocieties()->isEmpty()) {
+            // Can't access changes to the societies Association here, so
+            // it's neccessary to parse the JSON.
+            $socs_data = array_map('json_decode', $event->getEntityChangeSet()['societies_display_list']);
+            if (is_array($socs_data[0]) && is_array($socs_data[1])) {
+                $socs_data = [array_filter($socs_data[0], 'is_int'), array_filter($socs_data[1], 'is_int')];
+                if (array_diff($socs_data[0], $socs_data[1]) || array_diff($socs_data[1], $socs_data[0])) {
+                    if ($show->getAuthorised()) {
+                        $this->moderationManager->notifySocietyChanged($show);
+                    } else {
+                        $this->moderationManager->autoApproveOrEmailModerators($show);
+                        $authorisationEmailSent = true;
+                    }
+                }
             }
         }
 

--- a/src/Acts/CamdramBundle/EventListener/ShowListener.php
+++ b/src/Acts/CamdramBundle/EventListener/ShowListener.php
@@ -75,7 +75,7 @@ class ShowListener
     {
         $authorisationEmailSent = false;
 
-        if ($event->hasChangedField('society') && $show->getSociety() instanceof Society) {
+        if ($event->hasChangedField('society') && ! $show->getSocieties()->isEmpty()) {
             if ($show->getAuthorised()) {
                 $this->moderationManager->notifySocietyChanged($show);
             } else {

--- a/src/Acts/CamdramBundle/Form/Type/ShowType.php
+++ b/src/Acts/CamdramBundle/Form/Type/ShowType.php
@@ -3,6 +3,7 @@
 namespace Acts\CamdramBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -63,26 +64,15 @@ class ShowType extends AbstractType
             ))
             ->add('facebook_id', FacebookLinkType::class, array('required' => false))
             ->add('twitter_id', TwitterLinkType::class, array('required' => false))
-            ->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
-                //society's 'read-only' field is dependent on whether a new show is being created
-                $show = $event->getData();
-                $form = $event->getForm();
-
-                $disabled = $show
-                    && $show->getId() !== null
-                    && $show->getSociety() !== null
-                    && !$this->authorizationChecker->isGranted('ROLE_ADMIN')
-                    ;
-
-                $form->add('society', EntitySearchType::class, array(
-                    'route' => 'get_societies',
-                    'class' => 'Acts\\CamdramBundle\\Entity\\Society',
+            ->add('societies', CollectionType::class, array(
+                    'entry_type' => TextType::class,
+                    'allow_add' => true,
+                    'allow_delete' => true,
+                    'by_reference' => false,
+                    'label' => 'Societies',
                     'required' => false,
-                    'disabled' => $disabled,
-                    'text_field' => 'other_society'
-                ));
-            })
-        ;
+                    'mapped' => false
+            ));
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Acts/CamdramBundle/Service/ContactEntityService.php
+++ b/src/Acts/CamdramBundle/Service/ContactEntityService.php
@@ -54,8 +54,10 @@ class ContactEntityService
         $recipients = $this->aclProvider->getOwners($entity);
 
         if ($entity instanceof Show) {
-            if (count($recipients) == 0 && $entity->getSociety()) {
-                $recipients = $this->aclProvider->getOwners($entity->getSociety());
+            if (count($recipients) == 0) {
+                foreach ($entity->getSocieties() as $society) {
+                    $recipients = $this->aclProvider->getOwners($society);
+                }
             }
             if (count($recipients) == 0 && $entity->getVenue()) {
                 $recipients = $this->aclProvider->getOwners($entity->getVenue());

--- a/src/Acts/CamdramBundle/Service/EmailDispatcher.php
+++ b/src/Acts/CamdramBundle/Service/EmailDispatcher.php
@@ -110,7 +110,8 @@ class EmailDispatcher
     {
         $toEmails = $this->emailArrayFromUsers($moderators);
 
-        $message = (new \Swift_Message('Society changed to '. $show->getSociety()->getName() .': '.$show->getName()))
+        $message = (new \Swift_Message('Authorized society(s) changed to '. implode("; ",
+               $show->getSocieties()->map(function($s) { return $s->getName(); })->toArray())))
             ->setFrom(array($this->from_address => 'camdram.net'))
             ->setTo($toEmails)
             ->setBody(

--- a/src/Acts/CamdramBundle/Service/ModerationManager.php
+++ b/src/Acts/CamdramBundle/Service/ModerationManager.php
@@ -92,8 +92,8 @@ class ModerationManager
         $repo = $this->entityManager->getRepository('ActsCamdramSecurityBundle:User');
 
         if ($entity instanceof Show) {
-            if ($entity->getSociety()) {
-                $users = array_merge($users, $repo->getEntityOwners($entity->getSociety()));
+            foreach ($entity->getSocieties() as $society) {
+                $users = array_merge($users, $repo->getEntityOwners($society));
             }
             if ($entity->getVenue()) {
                 $users = array_merge($users, $repo->getEntityOwners($entity->getVenue()));
@@ -178,7 +178,10 @@ class ModerationManager
     {
         if ($entity instanceof Show) {
             $repo = $this->entityManager->getRepository('ActsCamdramSecurityBundle:User');
-            $moderators = $repo->getEntityOwners($entity->getSociety());
+            $moderators = [];
+            foreach ($entity->getSocieties() as $society) {
+                $moderators = array_merge($moderators, $repo->getEntityOwners($society));
+            }
             if (count($moderators) > 0) {
                 if ($this->tokenStorage->getToken()) {
                     $owners = array($this->tokenStorage->getToken()->getUser());

--- a/src/Acts/CamdramSecurityBundle/Security/Acl/Voter/ShowVoter.php
+++ b/src/Acts/CamdramSecurityBundle/Security/Acl/Voter/ShowVoter.php
@@ -39,8 +39,8 @@ class ShowVoter extends Voter
                 return true;
             }
         }
-        if ($subject->getSociety()) {
-            if ($this->aclProvider->isOwner($token->getUser(), $subject->getSociety())) {
+        foreach ($subject->getSocieties() as $society) {
+            if ($this->aclProvider->isOwner($token->getUser(), $society)) {
                 return true;
             }
         }

--- a/tests/CamdramBundle/Controller/ShowControllerTest.php
+++ b/tests/CamdramBundle/Controller/ShowControllerTest.php
@@ -110,7 +110,7 @@ class ShowControllerTest extends RestTestCase
             ->setCategory("comedy")
             ->setAuthorised(true)
             ->addPerformance($performance)
-            ->setSociety($society);
+            ->getSocieties()->add($society);
         $this->entityManager->persist($show);
         $this->entityManager->flush();
 

--- a/tests/CamdramBundle/Service/ContactEntityServiceTest.php
+++ b/tests/CamdramBundle/Service/ContactEntityServiceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Camdram\Tests\CamdramBundle\Service;
+
+use Acts\CamdramBundle\Entity\Show;
+use Acts\CamdramBundle\Entity\Society;
+use Acts\CamdramBundle\Entity\Venue;
+use Acts\CamdramSecurityBundle\Entity\User;
+use Acts\CamdramBundle\Service\ContactEntityService;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ContactEntityServiceTest extends TestCase
+{
+    /**
+     * @var MockObject
+     */
+    private $aclProvider;
+
+    /**
+     * @var MockObject
+     */
+    private $mailer;
+
+    private $users = [];
+
+    /**
+     * @var ContactEntityService
+     */
+    private $contactEntityService;
+
+    public function setUp()
+    {
+        $this->mailer = $this->getMockBuilder('\Swift_Mailer')
+            ->disableOriginalConstructor()->disableOriginalClone()->getMock();
+        $this->aclProvider = $this->getMockBuilder('\Acts\\CamdramSecurityBundle\\Security\\Acl\\AclProvider')
+            ->disableOriginalConstructor()->getMock();
+
+        $this->contactEntityService = new ContactEntityService($this->mailer, $this->aclProvider);
+
+        for ($i = 0; $i < 6; $i++) {
+            $user = new User();
+            $user->setName("User ".$i);
+            $user->setEmail("user".$i."@camdram.net");
+            $user->setIsEmailVerified(!($i&1));
+            $this->users[] = $user;
+        }
+    }
+
+    public function testEmailEntity() {
+        $showA = new Show();
+        $showB = new Show();
+        $showC = new Show();
+        $showD = new Show();
+        $showE = new Show();
+        $venue = new Venue();
+        $society = new Society();
+
+        $society->setName("Society 1");
+        $venue->setName("Venue 1");
+        $showA->setName("Show A")->setVenue($venue)->getSocieties()->add($society);
+        $showB->setName("Show B")->setVenue($venue)->getSocieties()->add($society);
+        $showC->setName("Show C")->getSocieties()->add($society);
+        $showD->setName("Show D")->setVenue($venue);
+        $showE->setName("Show E");
+        $this->aclProvider->method('getOwners')->will($this->returnValueMap([
+            [$showA, [$this->users[0], $this->users[1]]],
+            [$showB, []],
+            [$showC, []],
+            [$showD, []],
+            [$showE, []],
+            [$society, [$this->users[2], $this->users[3]]],
+            [$venue, [$this->users[4], $this->users[5]]],
+        ]));
+        $this->mailer->expects($this->exactly(7))->method("send")
+             ->with($this->callback(function($msg) {
+                 if ($msg->getFrom()['support@camdram.net'] != 'Camdram') return false;
+                 if (strpos($msg->getSubject(), 'Email Test') === false) return false;
+                 $matches = [];
+                 if (!preg_match('/receiving.*because.*(Show [A-E]|Society \d|Venue \d)/',
+                     $msg->getBody(), $matches)) return false;
+                 switch($matches[1]) {
+                     case "Show A":
+                         $this->assertSame(['user0@camdram.net' => 'User 0'], $msg->getTo());
+                         return true;
+                     case "Show B":
+                         $this->assertSame(['user2@camdram.net' => 'User 2'], $msg->getTo());
+                         return true;
+                     case "Show C":
+                         $this->assertSame(['user2@camdram.net' => 'User 2'], $msg->getTo());
+                         return true;
+                     case "Show D":
+                         $this->assertSame(['user4@camdram.net' => 'User 4'], $msg->getTo());
+                         return true;
+                     case "Show E":
+                         $this->assertSame(['support@camdram.net' => NULL], $msg->getTo());
+                         return true;
+                     case "Society 1":
+                         $this->assertSame(['user2@camdram.net' => 'User 2'], $msg->getTo());
+                         return true;
+                     case "Venue 1":
+                         $this->assertSame(['user4@camdram.net' => 'User 4'], $msg->getTo());
+                         return true;
+                     default:
+                         return false;
+                 }
+             }));
+
+        $this->contactEntityService->emailEntity($showA, "Camdram", "support@camdram.net", "Email Test", "A message");
+        $this->contactEntityService->emailEntity($showB, "Camdram", "support@camdram.net", "Email Test", "A message");
+        $this->contactEntityService->emailEntity($showC, "Camdram", "support@camdram.net", "Email Test", "A message");
+        $this->contactEntityService->emailEntity($showD, "Camdram", "support@camdram.net", "Email Test", "A message");
+        $this->contactEntityService->emailEntity($showE, "Camdram", "support@camdram.net", "Email Test", "A message");
+        $this->contactEntityService->emailEntity($society, "Camdram", "support@camdram.net", "Email Test", "A message");
+        $this->contactEntityService->emailEntity($venue, "Camdram", "support@camdram.net", "Email Test", "A message");
+    }
+}

--- a/tests/CamdramBundle/Service/EmailDispatcherTest.php
+++ b/tests/CamdramBundle/Service/EmailDispatcherTest.php
@@ -3,6 +3,7 @@
 namespace Camdram\Tests\CamdramBundle\Service;
 
 use Acts\CamdramBundle\Entity\Show;
+use Acts\CamdramBundle\Entity\Society;
 use Acts\CamdramSecurityBundle\Entity\User;
 use Acts\CamdramBundle\Service\EmailDispatcher;
 use PHPUnit\Framework\TestCase;
@@ -58,5 +59,26 @@ class EmailDispatcherTest extends TestCase
         $this->mailer->expects($this->once())->method('send');
 
         $this->emailDispatcher->sendShowCreatedEmail($show, $owners, $recipients, $admins);
+    }
+
+    public function testSendShowSocietyChangedEmail() {
+        $show = new Show();
+        $show->getSocieties()->add(new Society());
+        $owners = array('owner1', 'owner2');
+
+        $user1 = new User();
+        $user1->setEmail('user1@camdram.net');
+        $user2 = new User();
+        $user2->setEmail('user2@camdram.net');
+        $moderators = array(
+            $user1, $user2
+        );
+
+        $this->twig->expects($this->exactly(1))->method('render')
+            ->with($this->anything(), array('owners' => $owners, 'show' => $show))
+            ->will($this->returnValue('The message'));
+
+        $this->mailer->expects($this->once())->method('send');
+        $this->emailDispatcher->sendShowSocietyChangedEmail($show, $owners, $moderators);
     }
 }

--- a/tests/CamdramBundle/Service/ModerationManagerTest.php
+++ b/tests/CamdramBundle/Service/ModerationManagerTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Camdram\Tests\CamdramBundle\Service;
+
+use Acts\CamdramBundle\Entity\Show;
+use Acts\CamdramBundle\Entity\Society;
+use Acts\CamdramBundle\Entity\Venue;
+use Acts\CamdramBundle\Service\ModerationManager;
+use Acts\CamdramSecurityBundle\Entity\AccessControlEntry;
+use Acts\CamdramSecurityBundle\Entity\User;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ModerationManagerTest extends TestCase
+{
+    /**
+     * @var MockObject
+     */
+    private $entityManager;
+
+    /**
+     * @var MockObject
+     */
+    private $dispatcher;
+
+    /**
+     * @var MockObject
+     */
+    private $aclProvider;
+
+    /**
+     * @var MockObject
+     */
+    private $authorizationChecker;
+
+    /**
+     * @var MockObject
+     */
+    private $tokenStorage;
+
+    /**
+     * @var MockObject
+     */
+    private $logger;
+
+    /**
+     * @var MockObject
+     */
+    private $userRepo;
+
+    /**
+     * @var \Acts\CamdramBundle\Service\ModerationManager
+     */
+    private $moderationManager;
+
+    # Useful shared entities with some mocking common to all tests.
+    private $users = [];
+    private $admin;
+    private $society;
+    private $venue;
+    private $ownedShow;
+
+    public function setUp()
+    {
+        $this->entityManager = $this->getMockBuilder('Doctrine\\ORM\\EntityManager')
+            ->disableOriginalConstructor()->getMock();
+        $this->dispatcher = $this->getMockBuilder('\\Acts\\CamdramBundle\\Service\\EmailDispatcher')
+            ->disableOriginalConstructor()->getMock();
+        $this->aclProvider = $this->getMockBuilder('\\Acts\\CamdramSecurityBundle\\Security\\Acl\\AclProvider')
+            ->disableOriginalConstructor()->getMock();
+        $this->authorizationChecker = $this->getMockBuilder('\\Symfony\\Component\\Security\\Core\\Authorization\\AuthorizationCheckerInterface')
+            ->disableOriginalConstructor()->getMock();
+        $this->tokenStorage = $this->getMockBuilder('\\Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface')
+            ->disableOriginalConstructor()->getMock();
+        $this->logger = $this->getMockBuilder('\\Psr\\Log\\LoggerInterface')
+            ->disableOriginalConstructor()->getMock();
+        $this->userRepo = $this->getMockBuilder('\\Acts\\CamdramSecurityBundle\\Entity\\UserRepository')
+            ->disableOriginalConstructor()->getMock();
+
+        // Build mock entities
+        for ($i = 0; $i < 6; $i++) {
+            $user = new User();
+            $user->setName("User ".$i);
+            $user->setEmail("user".$i."@camdram.net");
+            $this->users[] = $user;
+        }
+        $this->admin = new User();
+        $this->admin->setName("Admin User");
+        $this->admin->setEmail("admin@camdram.net");
+        $this->admin->setIsEmailVerified(true);
+        $this->society = new Society();
+        $this->venue = new Venue();
+        $this->ownedShow = new Show();
+
+        // Any test should be able to retrieve the userRepo without further set-up.
+        $this->entityManager->expects($this->any())->method('getRepository')
+             ->will($this->returnValueMap([['ActsCamdramSecurityBundle:User', $this->userRepo]]));
+        $this->userRepo->method('findAdmins')->with(AccessControlEntry::LEVEL_FULL_ADMIN)
+             ->will($this->returnValue([$this->admin]));
+        $this->userRepo->method('getEntityOwners')->will($this->returnValueMap([
+            [$this->society, [$this->users[0], $this->users[1]]],
+            [$this->venue,   [$this->users[2], $this->users[3]]],
+            [$this->ownedShow, [$this->users[4]]]
+        ]));
+
+        $this->moderationManager = new ModerationManager($this->entityManager, $this->dispatcher,
+            $this->aclProvider, $this->authorizationChecker, $this->tokenStorage, $this->logger);
+    }
+
+    /**
+     * @covers Acts\CamdramBundle\Service\ModerationManager::getModeratorAdmins
+     * @covers Acts\CamdramBundle\Service\ModerationManager::getModeratorsForEntity
+     */
+    public function testGetModerators()
+    {
+        $show0 = new Show();
+        $showS = new Show();
+        $showV = new Show();
+        $showSV = new Show();
+        $showS->getSocieties()->add($this->society);
+        $showV->setVenue($this->venue);
+        $showSV->setVenue($this->venue)->getSocieties()->add($this->society);
+
+        $this->assertSame($this->moderationManager->getModeratorAdmins(), [$this->admin]);
+        $this->assertSame($this->moderationManager->getModeratorsForEntity($show0), [$this->admin]);
+        $this->assertSame($this->moderationManager->getModeratorsForEntity($showS), array_slice($this->users, 0, 2));
+        $this->assertSame($this->moderationManager->getModeratorsForEntity($showV), array_slice($this->users, 2, 2));
+        $this->assertSame($this->moderationManager->getModeratorsForEntity($showSV), array_slice($this->users, 0, 4));
+    }
+
+    public function testNotifySocietyChanged() {
+        $this->dispatcher->expects($this->once())->method('sendShowSocietyChangedEmail')
+            ->with($this->ownedShow, [$this->users[4]], array_slice($this->users, 0, 2));
+
+        # Show owned by users[4] and society, no token stored
+        $this->tokenStorage->method('getToken')->willReturn(null);
+        $this->ownedShow->getSocieties()->add($this->society);
+        $this->moderationManager->notifySocietyChanged($this->ownedShow);
+    }
+}

--- a/tests/CamdramSecurityBundle/Security/Acl/Voter/ShowVoterTest.php
+++ b/tests/CamdramSecurityBundle/Security/Acl/Voter/ShowVoterTest.php
@@ -47,7 +47,7 @@ class ShowVoterTest extends TestCase
         $show = new Show();
         $society = new Society();
         $society->setName('Test Society');
-        $show->setSociety($society);
+        $show->getSocieties()->add($society);
 
         $this->aclProvider->expects($this->any())->method('isOwner')
             ->with($this->user, $society)->will($this->returnValue(true));
@@ -69,7 +69,7 @@ class ShowVoterTest extends TestCase
         $show = new Show();
         $society = new Society();
         $society->setName('Test Society');
-        $show->setSociety($society);
+        $show->getSocieties()->add($society);
 
         $this->aclProvider->expects($this->atLeastOnce())->method('isOwner')
             ->with($this->user, $society)->will($this->returnValue(false));


### PR DESCRIPTION
There's a fairly large chunk of code here, so in summary:
* This is a fresh start from the code I wrote over the summer. (A bit of stuff from then was copy-pasted but there are significant differences.)
* I'm effectively trying to store three things: links between Show entities and Society entities, unregistered society strings attached to a Show, and the display ordering of those Societies and strings for each show.
* The best way I could see of storing that is a conventional many-many join table between Show and Society, coupled with a column on the Show table called `socs_list`. `socs_list` stores a JSON array of strings (unregistered societies) and ints (Society ids); this gives the ordering and the unregistered societies.
* Some parts of the code care about all the societies; they call `show->getPrettySocData()` (directly or through a further wrapper) and get `socs_list` with id's replaced with actual Society objects and corrections made for any deviation from the join table.
* Other parts of the code (e.g. access control) only care about the registered societies; they call `show->getSocieties()` and ignore the JSON fun.
* Unfortunately ShowListener is an exception to this approach; it only has access to the JSON and the parsing code has to be effectively duplicated here.
* The API is continuing to return information in its old format in addition to new (using the `getSoc*Legacy()` functions); this should obviously be phased out in time but I haven't picked a date as yet.