### PR TITLE
Add User Guidelines & update Privacy Policy #556

### DIFF
--- a/app/Resources/views/account/login.html.twig
+++ b/app/Resources/views/account/login.html.twig
@@ -16,6 +16,9 @@
     </div>
 {% endif %}
 
+<p>By logging in, you agree to follow our
+<a href="{{ path('acts_camdram_userguidelines') }}">User Guidelines</a>.</p>
+
 {{ render(path('hwi_oauth_connect')) }}
 
 {% if not app.user or app.user.externalUsers | length == 0 %}

--- a/app/Resources/views/account/login.html.twig
+++ b/app/Resources/views/account/login.html.twig
@@ -17,7 +17,9 @@
 {% endif %}
 
 <p>By logging in, you agree to follow our
-<a href="{{ path('acts_camdram_userguidelines') }}">User Guidelines</a>.</p>
+<a href="{{ path('acts_camdram_userguidelines') }}">User Guidelines</a> and confirm
+you are aware of our <a href="{{ path('acts_camdram_privacy') }}">Privacy
+Policy</a>.</p>
 
 {{ render(path('hwi_oauth_connect')) }}
 

--- a/app/Resources/views/layout.html.twig
+++ b/app/Resources/views/layout.html.twig
@@ -109,7 +109,7 @@
             <a href="{{ path('acts_camdram_about') }}">About Camdram</a><br/>
             <a href="{{ path('acts_camdram_development') }}">Development</a><br/>
             <a href="{{ path('acts_camdram_privacy') }}">Privacy &amp; Cookies</a><br/>
-            <a href="{{ path('acts_camdram_userpolicy') }}">User Policy</a><br/>
+            <a href="{{ path('acts_camdram_userguidelines') }}">User Guidelines</a><br/>
             <a href="{{ path('acts_camdram_faq') }}">FAQ</a><br/>
             <a href="{{ path('acts_camdram_contact_us') }}">Contact Us</a><br/>
         </div>

--- a/app/Resources/views/layout.html.twig
+++ b/app/Resources/views/layout.html.twig
@@ -109,6 +109,7 @@
             <a href="{{ path('acts_camdram_about') }}">About Camdram</a><br/>
             <a href="{{ path('acts_camdram_development') }}">Development</a><br/>
             <a href="{{ path('acts_camdram_privacy') }}">Privacy &amp; Cookies</a><br/>
+            <a href="{{ path('acts_camdram_userpolicy') }}">User Policy</a><br/>
             <a href="{{ path('acts_camdram_faq') }}">FAQ</a><br/>
             <a href="{{ path('acts_camdram_contact_us') }}">Contact Us</a><br/>
         </div>

--- a/app/Resources/views/show/form.html.twig
+++ b/app/Resources/views/show/form.html.twig
@@ -31,7 +31,14 @@
 <div class="form-large-row">
     {{ form_label(form.societies) }}
     <div>
-        <p>Registered societies will appear in the search pop-up, but you can also add societies that aren't registered with Camdram. Adding a registered society allows its admins to approve and edit your show.
+        <p><small>
+            Registered societies will appear in the search pop-up,
+            but you can also add societies that aren't registered with Camdram.
+            Adding a registered society allows its admins to approve and edit
+            your show. &nbsp;
+            <a href="{{ path('acts_camdram_faq') }}#newsociety">How do societies
+            become registered with Camdram?</a>
+            </small>
         {{ form_errors(form.societies) }}</p>
         <div class="linked-societies" data-prototype="{% filter escape('html') %}{% include 'show/society-form.html.twig' with {society: form.societies.vars.prototype} %}{% endfilter %}">
             {% for society in form.societies %}
@@ -48,7 +55,15 @@
 <div class="form-large-row">
     {{ form_label(form.description) }}
     <div>
-         <p>You can now format your show descriptions using Markdown. Links just work, <strong>**bold**</strong>, <em>*italics*</em>, and <b style="display: inline-block">## Headings</b> are also available. See <a href="https://help.github.com/articles/basic-writing-and-formatting-syntax/">this page</a> for a rough guide, although not all features are available.</p>
+        <p><small>You can now format your show descriptions using Markdown.
+           Links just work, <strong>**bold**</strong>, <em>*italics*</em>,
+           and <b style="display: inline-block">## Headings</b> are also available.
+           See <a href="https://help.github.com/articles/basic-writing-and-formatting-syntax/" target="_blank">this page</a>
+           for a rough guide, although not all features are available.</small></p>
+
+        <p><small>Write this with the general public in mind – what is this show and why
+            should somebody come to see it? Don't mention auditions or production
+            team vacancies: you'll add them later.</small></p>
          {{ form_widget(form.description) }}
          {{ form_errors(form.description) }}
     </div>
@@ -85,6 +100,17 @@
         </div>
     </div>
 </div>
+
+{% if not is_granted('APPROVE', form.vars.data) %}
+    <p class="panel">After you click 'Create', this show will not be public
+    until moderators (normally the society and venue adminstrators) approve it.
+    Please be patient: this may take a few days. You can make changes while waiting
+    for approval.
+    Camdram's volunteer site admins moderate shows without a registered society
+    or venue.
+    </p>
+{% endif %}
+
 
 {{ form_rest(form) }}
 

--- a/app/Resources/views/show/new.html.twig
+++ b/app/Resources/views/show/new.html.twig
@@ -6,6 +6,10 @@
 
 <h3>Create a new show</h3>
 <div class="panel">
+    <p>Please ensure you're familiar with our
+    <a href="{{ path('acts_camdram_userguidelines') }}">User Guidelines</a>
+    and <a href="{{ path('acts_camdram_faq') }}#suitability">Show Suitability Guidelines</a> first.</p>
+
     <p>Required fields are marked with an asterisk (*). You can change any field later, with the
     possible exception of Society: please contact us to change it later if neccessary.
     Once the show is created you'll be able to add a
@@ -14,9 +18,14 @@
     <p>Write a Description with the general public in mind – what is this show and why
     should somebody come to see it? You can add auditions and production team vacancies
     separately once the show is created; they don't need to be mentioned here.</p>
+
     {% if not is_granted('APPROVE', form.vars.data) %}
-        <p>When you click 'create', it will be sent to a moderator, who it check it over before it
-        appears on Camdram.</p>
+        <p>When you click 'Create', this information will be sent to moderators,
+        who will have to review and approve it before it appears on Camdram.
+        If you enter a society or venue that is registered on Camdram, they will
+        be responsible for show approval; if not, Camdram's volunteer website
+        admins will do this. Please allow time for this step.
+        </p>
     {% endif %}
 </div>
 <form action="{{ path("post_show") }}" method="post" class="">

--- a/app/Resources/views/show/new.html.twig
+++ b/app/Resources/views/show/new.html.twig
@@ -14,9 +14,9 @@
         Suitability Guidelines</a> first.
     </p>
 
-    <p> Required fields are marked with an asterisk (*). You can change any field
-        later, except possibly Societies: contact us for help with that.
-        You don't need to enter things like "Unknown" or "TBC".
+    <p> Required fields are marked with an asterisk (*). You don't need to enter
+        things like "Unknown" or "TBC" in other (optional) fields, and you can change
+        things later. Please do check for silly mistakes, though!
         Publicity images, audition adverts and production team vacancies can be added
         after the show is created.
     </p>

--- a/app/Resources/views/show/new.html.twig
+++ b/app/Resources/views/show/new.html.twig
@@ -5,28 +5,22 @@
 {% block body %}
 
 <h3>Create a new show</h3>
+
 <div class="panel">
-    <p>Please ensure you're familiar with our
-    <a href="{{ path('acts_camdram_userguidelines') }}">User Guidelines</a>
-    and <a href="{{ path('acts_camdram_faq') }}#suitability">Show Suitability Guidelines</a> first.</p>
+    <p> Please ensure you're familiar with our
+        <a href="{{ path('acts_camdram_userguidelines') }}">User
+        Guidelines</a> and
+        <a href="{{ path('acts_camdram_faq') }}#suitability">Show
+        Suitability Guidelines</a> first.
+    </p>
 
-    <p>Required fields are marked with an asterisk (*). You can change any field later, with the
-    possible exception of Society: please contact us to change it later if neccessary.
-    Once the show is created you'll be able to add a
-    publicity image (please ensure you have permission to use it!).</p>
+    <p> Required fields are marked with an asterisk (*). You can change any field
+        later, except possibly Societies: contact us for help with that.
+        You don't need to enter things like "Unknown" or "TBC".
+        Publicity images, audition adverts and production team vacancies can be added
+        after the show is created.
+    </p>
 
-    <p>Write a Description with the general public in mind – what is this show and why
-    should somebody come to see it? You can add auditions and production team vacancies
-    separately once the show is created; they don't need to be mentioned here.</p>
-
-    {% if not is_granted('APPROVE', form.vars.data) %}
-        <p>When you click 'Create', this information will be sent to moderators,
-        who will have to review and approve it before it appears on Camdram.
-        If you enter a society or venue that is registered on Camdram, they will
-        be responsible for show approval; if not, Camdram's volunteer website
-        admins will do this. Please allow time for this step.
-        </p>
-    {% endif %}
 </div>
 <form action="{{ path("post_show") }}" method="post" class="">
 

--- a/app/Resources/views/static/privacy.html.twig
+++ b/app/Resources/views/static/privacy.html.twig
@@ -101,7 +101,10 @@ hold to authorities if required to by law.</p>
         listing(s). Society or venue administrators can also help with these requests.
         Camdram provides contact forms for this purpose on show, society and venue pages.
     <li>You can also <a href="{{ path('acts_camdram_contact_us') }}">contact</a> the
-        Camdram central administrative team with such requests if necessary.
+        Camdram central administrative team with such requests if necessary. We will
+        always respect our obligations under law regarding these requests. Please
+        note, however, that we will need to verify identity before we can act, and
+        that as volunteers, our response times may be slower.
     <li>If you feel another user is not complying with the User Guidelines,
         please contact us and we will investigate.
 </ul>

--- a/app/Resources/views/static/privacy.html.twig
+++ b/app/Resources/views/static/privacy.html.twig
@@ -84,6 +84,29 @@ hold to authorities if required to by law.</p>
 
 </ul>
 
+<h4>Data added to Camdram by users</h4>
+
+<ul>
+    <li>Data contributed by site users is a fundamental part of Camdram's purpose.
+        This includes personal information, particularly names of people involved
+        with shows listed on Camdram.
+    <li>This data is available publicly, both within Camdram and via other websites
+        that reuse our data (including search engines and other websites).
+    <li>This information is submitted and managed by Camdram users individually,
+        rather than by the Camdram administrative team. Users submitting data to
+        Camdram are subject to our <a href="{{ path('acts_camdram_userguidelines') }}">
+        User Guidelines</a>.
+    <li>Requests to correct or remove this user-managed data, where possible,
+        should be made initially to the administrators for the particular show
+        listing(s). Society or venue administrators can also help with these requests.
+        Camdram provides contact forms for this purpose on show, society and venue pages.
+    <li>You can also <a href="{{ path('acts_camdram_contact_us') }}">contact</a> the
+        Camdram central administrative team with such requests if necessary.
+    <li>If you feel another user is not complying with the User Guidelines,
+        please contact us and we will investigate.
+</ul>
+
+
 <br/>
 
 <h2 id="cookies">Cookies</h2>

--- a/app/Resources/views/static/privacy.html.twig
+++ b/app/Resources/views/static/privacy.html.twig
@@ -7,49 +7,83 @@
 
 <p>This page describes what data this website collects about you.
 The general rule is that we try not to be evil;
-camdram.net does store and log personal information if you create an
-account with us, but we do not disclose it to anyone without good reason.
+Camdram does store and log some information for particular purposes,
+but we do not disclose it to anyone without good reason.
 If you have any questions, please contact
 <a href="mailto:support@camdram.net?Subject=Privacy%20policy" target="_top">support@camdram.net</a>.
 </p>
 
+<p>This page uses the same noun and pronoun definitions as our
+<a href="{{ path('acts_camdram_userguidelines') }}">User Guidelines</a>.
+Camdram is governed by English law. We will provide any information we
+hold to authorities if required to by law.</p>
+
+<p>We may update this Privacy Policy at any time. The applicable version
+    is always the one accessible on this website. If we make significant
+    changes, we will make reasonable efforts to tell registered users
+    about the change, usually via email. If you continue to use Camdram,
+    you agree to follow the latest version of the User Guidelines.
+    </p>
+
+<h4>Data collected whenever you visit this website</h4>
+
 <ul>
     <li>Our web server collects the domain name and IP address of the
-    host from which you access the internet, the browser software you use
-    and your operating system, the date and time you access each page, and
-    the domain name of the site which linked to camdram.net.
+    host from which you access the internet; the operating system and
+    browser software you use; the date and time you access each page; and
+    the domain name of the site which linked to Camdram.
 
     <li>This data is used to determine the number of visitors to different
     sections of our site, and to create statistics about what browser or
     operating system they use. We do not use it to track or record personal
     information. The raw data is not disclosed to anyone outside the
-    camdram.net administrative team, with the exception of Google, our analytics
-    provider—see below. Anonymised statistics may be made publicly available.
+    Camdram administrative team, with the exception of Google, our analytics
+    provider (see Cookies section below).
+    Anonymised statistics may be made publicly available.
 
-    <li>When you create an account on camdram.net, you may provide
-    optional personal information about yourself. This information is used
-    to obtain anonymous statistics about the users of our site, and to
-    contact you if you are a society administrator with questions we may
-    have about your society's shows. The raw data is not disclosed to anyone
-    outside the camdram.net administrative team. Anonymised statistics may
-    be made publically available.
+</ul>
 
-    <li>In the event of technical issues with the website, error messages are
-    sent to Sentry (<a href="https://sentry.io" target="_blank">https://sentry.io</a>), to
-    enable us to identify and resolve problems as quickly as possible. If you
-    are logged in at the time, your email address is included.
+<h4>Data collected if you log in to Camdram</h4>
 
-    <li>If you identify yourself by logging in to camdram.net, we log any
-    administrative actions you take on the website. This is used for
-    debugging and security purposes. This information is not disclosed to
-    anyone outside the camdram.net administrative team.
+<ul>
+    <li>If you choose to log in to Camdram, we collect and store the
+        name and email address you have associated with the login provider
+        you used (e.g. Raven, Facebook). By logging in, you consent to this and to
+        us contacting you via email very occasionally, with essential information
+        or queries regarding your use of Camdram.
+        In general, this is no more than two or three emails per year.
 
     <li>The email address you register to your account may be visible to other
-    relevant users in some scenarios. For example, when a email is sent to a
-    society's admins, it is sent with recipients visible to each other for clarity.
+        Camdram users in some scenarios. For example, when a email is sent to a
+        society's admins, it is sent with recipients visible to each other for clarity.
 
-    <li>We will provide any information to authorities if required to by law.
+    <li>In the event of technical issues with the website, error messages are
+        sent to Sentry (<a href="https://sentry.io" target="_blank">https://sentry.io</a>), to
+        enable us to identify and resolve problems as quickly as possible. If you
+        are logged in at the time, your email address is included in these error messages.
+        This data is not public, but will be available to certain people outside
+        the Camdram administrative team (for example, employees of Sentry).
+
+    <li>If you configure your Camdram log in account to be able to use more than
+        one login provider, we also store email addresses associated with the other
+        accounts, and information about these links (for example,
+        that a particular Facebook account is the same person as a particular Google
+        account). This information is not disclosed to
+        anyone outside the Camdram administrative team.
+
+    <li>You may also provide optional personal information about yourself as part
+        of your Camdram account. This information is used
+        to obtain anonymous statistics about the users of our site.
+        The raw data is not disclosed to anyone
+        outside the Camdram administrative team. Anonymised statistics may
+        be made publically available.
+
+    <li>We log any administrative actions you take on the website while logged in.
+        This is for debugging and security purposes. This information is not disclosed to
+        anyone outside the Camdram administrative team.
+
 </ul>
+
 <br/>
 
 <h2 id="cookies">Cookies</h2>
@@ -68,8 +102,9 @@ around the site correctly. Camdram uses a cookie to maintain information
 about the current session, allowing a user to be uniquely identified between
 pages as they navigate around the site.</p>
 
-<p>Functionality cookies allow Camdram to enable the 'remember me' functionality
-for logging in to Camdram.</p>
+<p>A cookie is also used to enable the 'remember me' functionality
+for logging in to Camdram. You only receive this cookie if you make use of that
+feature for convenience.</p>
 
 <p>Camdram uses Google Analytics to understand how our users interact with the site,
 improve performance, and provide a better user experience.

--- a/app/Resources/views/static/privacy.html.twig
+++ b/app/Resources/views/static/privacy.html.twig
@@ -15,8 +15,9 @@ If you have any questions, please contact
 
 <p>This page uses the same noun and pronoun definitions as our
 <a href="{{ path('acts_camdram_userguidelines') }}">User Guidelines</a>.
-Camdram is governed by English law. We will provide any information we
-hold to authorities if required to by law.</p>
+For legal purposes, the data controller is the collective group of volunteers
+who manage Camdram. Camdram is governed by English law.
+We will provide any information we hold to authorities if required to by law.</p>
 
 <p>We may update this Privacy Policy at any time. The applicable version
     is always the one accessible on this website. If we make significant

--- a/app/Resources/views/static/privacy.html.twig
+++ b/app/Resources/views/static/privacy.html.twig
@@ -5,13 +5,18 @@
 {% block body %}
 <h2 id="privacy">Privacy Policy</h2>
 
-<p>This page describes what data this website collects about you.
-The general rule is that we try not to be evil;
-Camdram does store and log some information for particular purposes,
-but we do not disclose it to anyone without good reason.
-If you have any questions, please contact
-<a href="mailto:support@camdram.net?Subject=Privacy%20policy" target="_top">support@camdram.net</a>.
-</p>
+<div class="panel">
+
+    <h4>Summary</h4>
+
+    <p>This page describes what data this website collects about you.
+    The general rule is that we try not to be evil;
+    Camdram does store and log some information for particular purposes,
+    but we do not disclose it to anyone without good reason.
+    If you have any questions, please contact
+    <a href="mailto:support@camdram.net?Subject=Privacy%20policy" target="_top">support@camdram.net</a>.
+    </p>
+</div>
 
 <p>This page uses the same noun and pronoun definitions as our
 <a href="{{ path('acts_camdram_userguidelines') }}">User Guidelines</a>.

--- a/app/Resources/views/static/privacy.html.twig
+++ b/app/Resources/views/static/privacy.html.twig
@@ -5,68 +5,81 @@
 {% block body %}
 <h2 id="privacy">Privacy Policy</h2>
 
-<p>This page describes what data camdram.net collects about you when you
-use the website. The general rule is that we try not to be evil;
+<p>This page describes what data this website collects about you.
+The general rule is that we try not to be evil;
 camdram.net does store and log personal information if you create an
 account with us, but we do not disclose it to anyone without good reason.
 If you have any questions, please contact
-<a href="mailto:support@camdram.net?Subject=Privacy%20policy" target="_top">support@camdram.net</a>.</p>
+<a href="mailto:support@camdram.net?Subject=Privacy%20policy" target="_top">support@camdram.net</a>.
+</p>
 
-<ul><li>Our web server collects the domain name and IP address of the
-host from which you access the internet, the browser software you use
-and your operating system, the date and time you access each page, and
-the domain name of the site which linked to camdram.net.</li>
+<ul>
+    <li>Our web server collects the domain name and IP address of the
+    host from which you access the internet, the browser software you use
+    and your operating system, the date and time you access each page, and
+    the domain name of the site which linked to camdram.net.
 
-<li>This data is used to determine the number of visitors to different
-sections of our site, and to create statistics about what browser or
-operating system they use. We do not use it to track or record personal
-information. The raw data is not disclosed to anyone outside the
-camdram.net administrative team, with the exception of Google, our analytics
-provider—see below. Anonymised statistics may be made publicly available.</li>
+    <li>This data is used to determine the number of visitors to different
+    sections of our site, and to create statistics about what browser or
+    operating system they use. We do not use it to track or record personal
+    information. The raw data is not disclosed to anyone outside the
+    camdram.net administrative team, with the exception of Google, our analytics
+    provider—see below. Anonymised statistics may be made publicly available.
 
-<li>When you create an account on camdram.net, you may provide
-optional personal information about yourself. This information is used
-to obtain anonymous statistics about the users of our site, and to
-contact you if you are a society administrator with questions we may
-have about your society's shows. The raw data is not disclosed to anyone
-outside the camdram.net administrative team. Anonymised statistics may
-be made publically available.</li>
+    <li>When you create an account on camdram.net, you may provide
+    optional personal information about yourself. This information is used
+    to obtain anonymous statistics about the users of our site, and to
+    contact you if you are a society administrator with questions we may
+    have about your society's shows. The raw data is not disclosed to anyone
+    outside the camdram.net administrative team. Anonymised statistics may
+    be made publically available.
 
-<li>In the event of technical issues with the website, error messages are
-sent to Sentry (<a href="https://sentry.io">https://sentry.io</a>), to
-enable us to identify and resolve problems as quickly as possible. If you
-are logged in at the time, your email address is included.</li>
+    <li>In the event of technical issues with the website, error messages are
+    sent to Sentry (<a href="https://sentry.io" target="_blank">https://sentry.io</a>), to
+    enable us to identify and resolve problems as quickly as possible. If you
+    are logged in at the time, your email address is included.
 
-<li>If you identify yourself by logging in to camdram.net, we log any
-administrative actions you take on the website. This is used for
-debugging and security purposes. This information is not disclosed to
-anyone outside the camdram.net administrative team.</li>
+    <li>If you identify yourself by logging in to camdram.net, we log any
+    administrative actions you take on the website. This is used for
+    debugging and security purposes. This information is not disclosed to
+    anyone outside the camdram.net administrative team.
 
-<li>The email address you register to your account may be visible to other
-relevant users in some scenarios. For example, when a email is sent to a
-society's admins, it is sent with recipients visible to each other for clarity.
+    <li>The email address you register to your account may be visible to other
+    relevant users in some scenarios. For example, when a email is sent to a
+    society's admins, it is sent with recipients visible to each other for clarity.
 
-<li>We will provide any information to authorities if required to by
-law.</li></ul>
+    <li>We will provide any information to authorities if required to by law.
+</ul>
+<br/>
 
 <h2 id="cookies">Cookies</h2>
-<p>To find out about what cookies are, take a look at these websites.</p>
+
+<p>There are good explanations of what 'cookies' are on other websites, such as: </p>
 <ul>
-    <li><a href="http://www.bbc.co.uk/privacy/cookies/">www.bbc.co.uk</a></li>
-    <li><a href="http://ico.org.uk/for_the_public/topic_specific_guides/online/cookies">The Information Commissioner's Office.</a></li>
+    <li><a href="http://www.bbc.co.uk/usingthebbc/cookies/what-do-i-need-to-know-about-cookies/" target="_blank">the BBC</a></li>
+    <li><a href="https://ico.org.uk/your-data-matters/online/cookies/" target="_blank">the Information Commissioner's Office</a></li>
 </ul>
-<h3>How does Camdram use cookies?</h3>
+<br/>
+
+<h4>How does Camdram use cookies?</h4>
+
 <p>Some cookies are strictly necessary in order for users to navigate
 around the site correctly. Camdram uses a cookie to maintain information
 about the current session, allowing a user to be uniquely identified between
 pages as they navigate around the site.</p>
+
 <p>Functionality cookies allow Camdram to enable the 'remember me' functionality
 for logging in to Camdram.</p>
-<p>Camdram uses Google Analytics to improve performance of the site and
-provide a better user experience. More information about what cookies are
-used by Google Analytics can be found <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage">here</a>.
-This is a tool commonly used on popular websites, including <a href="http://www.gov.uk">www.gov.uk</a> and
-<a href="http://www.bbc.co.uk">the BBC</a>. Google provide a plug-in for
-most common browsers allowing users to <a href="https://tools.google.com/dlpage/gaoptout">opt out</a>.
+
+<p>Camdram uses Google Analytics to understand how our users interact with the site,
+improve performance, and provide a better user experience.
+Google Analytics is used by many popular websites (for example,
+<a href="http://www.gov.uk" target="_blank">Gov.uk</a> or
+<a href="http://www.bbc.co.uk" target="_blank">the BBC</a>)
+and depends on cookies to work correctly. More information about
+the cookies used by Google Analytics can be found
+<a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage" target="_blank">here</a>.
+If you want to opt out of these cookies, Google provide
+<a href="https://tools.google.com/dlpage/gaoptout" target="_blank">a browser plug-in</a> for this.
 </p>
 {% endblock %}

--- a/app/Resources/views/static/user-guidelines.html.twig
+++ b/app/Resources/views/static/user-guidelines.html.twig
@@ -4,9 +4,11 @@
 
 {% block body %}
 
-<h2>Camdram User Guidelines</h2>
+<h2>User Guidelines</h2>
 
-<h3>Summary</h3>
+<div class="panel">
+
+    <h4>Summary</h4>
 
     <p>If you log in to Camdram, you agree to:</p>
     <ol>
@@ -16,11 +18,9 @@
     </ol>
     <br />
     <p>
-        Please read on for more information; we've tried to keep this
-        brief and clear.
+        Please read on; we've tried to keep this brief and clear.
     </p>
-
-<h3>Basics</h3>
+</div>
 
     <p>In these Guidelines:</p>
     <ul>
@@ -43,7 +43,7 @@
         <a href="{{ path('acts_camdram_privacy') }}">Privacy Policy</a>.
     </p>
 
-<h3>Changing and enforcing the Guidelines</h3>
+<h5>Changing and enforcing the Guidelines</h5>
 
     <p>
         We may change the User Guidelines at any time. The applicable version
@@ -55,26 +55,26 @@
 
     <p>
         We will remove any content that we know or reasonably suspect does
-        not align with these Guidelines. We may suspend or ban users who
-        ignore the Guidelines deliberately or repeatedly. We will be
-        reasonable in how we apply these powers but final decisions will
-        rest with us alone.
+        not align with these Guidelines, probably without warning.
+        We may suspend or ban users who ignore the Guidelines deliberately
+        or repeatedly. We will be reasonable in how we apply these powers
+        but final decisions will rest with us alone.
     </p>
 
-<h3>Guidelines in detail</h3>
+<div class="panel">
+    <h5>Principle 1: Show listings must be genuine and accurate</h5>
 
-<p><strong>Show listings must be genuine and accurate</strong></p>
-
-<p><strong>WHY?</strong>
-    Camdram is meant to be an accurate historical record, and a trustworthy
-    data source for other websites that reuse content from Camdram.
-</p>
+    <p>
+        Camdram is meant to be an accurate historical record, and a trustworthy
+        data source for other websites.
+    </p>
+</div>
 
     <ul>
     <li>You must only create show listings for genuine productions or
         performances, that are aligned with our current
         <a href="{{ path('acts_camdram_faq') }}#suitability">
-        suitability guidelines</a>.
+        Suitability Guidelines</a>.
     <li>It is absolutely OK to create listings for productions which have an element of
         uncertainty over whether they will be able to go ahead, for practical / logistic
         reasons (e.g. funding), provided there's a genuine desire and effort to make them
@@ -90,8 +90,7 @@
         time or location is changed. This also includes information in show descriptions.
     <li>Show listings do not need to be deadly serious. Humour is great, especially if
         it fits the production. However, listings should always be grounded in fact.
-    <li>We want Camdram to be accessible, inclusive and welcoming to as wide an
-        audience as possible. You must not go out of your way to embed in-jokes in show
+    <li>You must not go out of your way to embed in-jokes in show
         listings or otherwise make the listing inscrutable or incomprehensible to a
         general audience.
     <li>All people listed as having participated in a production (cast, band and
@@ -100,18 +99,20 @@
             <li>Cast should be credited according to the script, libretto or other source
                 text, where applicable.
             <li>You should use standard role titles where possible for production team.
-            <li>Humorous roles are fine provided they describe genuine participation
+            <li>Humorous titles are fine provided they describe genuine participation
                 (&lsquo;Technical Overlord&rsquo; is fine, for example).
             </ul>
     </ul>
     <br />
 
-<p><strong>Show listings must be legal and reasonable</strong></p>
+<div class="panel">
+    <h5>Principle 2: Show listings must be legal and reasonable</h5>
 
-<p><strong>WHY?</strong>
-    We want Camdram to be accessible and welcoming to all visitors.
-    Legal action would probably force Camdram to shut down permanently.
-</p>
+    <p>
+        We want Camdram to be inclusive and welcoming to all visitors.
+        Legal action would probably force Camdram to shut down permanently.
+    </p>
+</div>
 
     <ul>
     <li>You must not use Camdram to incite hatred or prejudice.
@@ -123,12 +124,14 @@
     </ul>
     <br />
 
-<p><strong>Respect copyright &amp; plagiarism law</strong></p>
+<div class="panel">
+    <h5>Principle 3: Respect copyright &amp; plagiarism law</h5>
 
-<p><strong>WHY?</strong>
-    We could face legal action if Camdram hosts copyrighted or
-    plagiarised content (images, text or other formats).
-</p>
+    <p>
+        We could face legal action if Camdram hosts copyrighted or
+        plagiarised content (images, text or other formats).
+    </p>
+</div>
 
     <ul>
     <li>You must ensure you have permission (or &lsquo;rights&rsquo;) to use
@@ -140,12 +143,14 @@
     </ul>
     <br />
 
-<p><strong>Respect personal data privacy</strong></p>
+<div class="panel">
+    <h5>Principle 4: Respect personal data privacy</h5>
 
-<p><strong>WHY?</strong>
-    We could face legal action if Camdram doesn't comply with
-    laws regarding the use of personal data.
-</p>
+    <p>
+        We could face legal action if Camdram doesn't comply with
+        laws regarding the use of personal data.
+    </p>
+</div>
 
     <ul>
     <li>If you wish to add someone's name as a participant (cast, crew or band member)

--- a/app/Resources/views/static/user-guidelines.html.twig
+++ b/app/Resources/views/static/user-guidelines.html.twig
@@ -154,7 +154,8 @@
 
     <ul>
     <li>If you wish to add someone's name as a participant (cast, crew or band member)
-        in a show, you must ensure you have their consent for that information to appear in:
+        in a show, you <strong>must</strong> ensure you have their consent for that
+        information to appear in:
             <ul>
                 <li>Camdram's show listings, which are accessible to the general public
                     as well as search engines;
@@ -165,6 +166,10 @@
         to add their name, and allow reasonable time for them to object or opt-out).
     <li>Do not assume permission solely because the person is already listed on other
         shows on Camdram.
+    <li>Be aware that there are many potential reasons why someone might not want
+        their name to be visible on Camdram. For example, it indicates the
+        city they currently live in, and even identifies their exact location
+        at a particular date and time.
     <li>For participants under 18 years old, you must also have the consent of a
         parent or legal guardian.
     </ul>

--- a/app/Resources/views/static/user-guidelines.html.twig
+++ b/app/Resources/views/static/user-guidelines.html.twig
@@ -144,7 +144,7 @@
     <br />
 
 <div class="panel">
-    <h5>Principle 4: Respect personal data privacy</h5>
+    <h5>Principle 4: Respect personal data privacy law</h5>
 
     <p>
         We could face legal action if Camdram doesn't comply with
@@ -165,6 +165,8 @@
         to add their name, and allow reasonable time for them to object or opt-out).
     <li>Do not assume permission solely because the person is already listed on other
         shows on Camdram.
+    <li>For participants under 18 years old, you must also have the consent of a
+        parent or legal guardian.
     </ul>
     <br />
 

--- a/app/Resources/views/static/user-guidelines.html.twig
+++ b/app/Resources/views/static/user-guidelines.html.twig
@@ -10,16 +10,16 @@
 
     <p>If you log in to Camdram, you agree to:</p>
     <ol>
-    <li>Obey laws regarding copyright, plagiarism and personal data privacy;
-    <li>Only create genuine, accurate show listings, and describe them legally
-        and reasonably.
+    <li>Only create show listings that are genuine, accurate and appropriate;
+    <li>Create and manage listings in accordance with English law, especially
+        regarding copyright, plagiarism, and personal data privacy.
     </ol>
     <p>
         Please read on for more information; we've tried to keep this
         brief and clear.
     </p>
 
-<h3>Definitions</h3>
+<h3>Basics</h3>
 
     <p>In these Guidelines:</p>
     <ul>
@@ -34,18 +34,15 @@
         roles, vacancies and adverts.
     </ul>
 
+    <br />
     <p>
-        Camdram is governed by English law. Whilst run for the benefit of the Cambridge
+        Camdram is subject to English law. Whilst run for the benefit of the Cambridge
         student amateur theatrical community, Camdram is officially unaffiliated with any
-        theatre or educational institution.
-    </p>
-
-    <p>
-        By using Camdram you also accept our
+        theatre or educational institution. By using Camdram you also accept our
         <a href="{{ path('acts_camdram_privacy') }}">Privacy Policy</a>.
     </p>
 
-<h3>Changes to the Guidelines</h3>
+<h3>Changing and enforcing the Guidelines</h3>
 
     <p>
         We may change the User Guidelines at any time. The applicable version
@@ -54,8 +51,6 @@
         usually via email. If you continue to use Camdram, you agree to follow
         the latest version of the User Guidelines.
     </p>
-
-<h3>Enforcing the Guidelines</h3>
 
     <p>
         We will remove any content that we know or reasonably suspect does
@@ -67,27 +62,13 @@
 
 <h3>Guidelines in detail</h3>
 
-<h4>Respect copyright &amp; plagiarism law</h4>
-
-    <ul>
-    <li>We could be sued for hosting copyrighted or plagiarised content (images, text or other
-        formats). Any legal action would likely cause Camdram to shut down permanently.
-    <li>We rely on and trust you to ensure you have permission (or &lsquo;rights&rsquo;) to use
-        images or descriptive text added to Camdram. You must include credits or citations where
-        needed.
-    <li>Absence of a copyright statement or mark (like &copy; or &trade;) does not automatically
-        mean content can be used freely or without permission. You must assume you cannot use
-        content until you know for sure you can.
-    </ul>
-    <br />
-
-<h4>Show listings must be genuine and accurate</h4>
+<p><strong>Show listings must be genuine and accurate</strong></p>
 
     <ul>
     <li>Part of the purpose of Camdram is to be an accurate historical record.
     <li>Other third-party websites reuse content from Camdram.
     <li>You must only create show listings for genuine productions or performances,
-        that are aligned with our Suitability Guidelines (LINK).                                <!-- TODO -->
+        that are aligned with our <a href="{{ path('acts_camdram_userguidelines') }}">Suitability Guidelines</a>.             <!-- TODO -->
     <li>It is absolutely OK to create listings for productions which have an element of
         uncertainty over whether they will be able to go ahead, for practical / logistic
         reasons (e.g. funding), provided there's a genuine desire and effort to make them
@@ -119,7 +100,34 @@
     </ul>
     <br />
 
-<h4>Respect personal data privacy</h4>
+<p><strong>Show listings must be legal and reasonable</strong></p>
+    <ul>
+    <li>We need to keep Camdram as accessible and welcoming to all visitors as
+        possible, as well as preventing any legal action against the website.
+    <li>You must not use Camdram to incite hatred or prejudice.
+    <li>Images uploaded to Camdram must not be illegal, nor inappropriate for a general
+        audience.
+    <li>Content of show listings must not be gratuitously or needlessly obscene.
+        Explicit language is OK if justified by the show for artistic reasons; unnecessary
+        swearing in descriptions or role titles is not.
+    </ul>
+    <br />
+
+<p><strong>Respect copyright &amp; plagiarism law</strong></p>
+
+    <ul>
+    <li>We could be sued for hosting copyrighted or plagiarised content (images, text or other
+        formats). Any legal action would likely cause Camdram to shut down permanently.
+    <li>We rely on and trust you to ensure you have permission (or &lsquo;rights&rsquo;) to use
+        images or descriptive text added to Camdram. You must include credits or citations where
+        needed.
+    <li>Absence of a copyright statement or mark (like &copy; or &trade;) does not automatically
+        mean content can be used freely or without permission. You must assume you cannot use
+        content until you know for sure you can.
+    </ul>
+    <br />
+
+<p><strong>Respect personal data privacy</strong></p>
 
     <ul>
     <li>If you wish to add someone's name as a participant (cast, crew or band member)
@@ -127,7 +135,8 @@
             <ul>
                 <li>Camdram's show listings, which are accessible to the general public
                     as well as search engines;
-                <li>Third party websites that follow our Acceptable Use Policy (LINK).          <!-- TODO -->
+                <li>Third party websites that follow our
+                    <a href="{{ path('acts_camdram_userguidelines') }}">Acceptable Use Policy</a>.                         <!-- TODO -->
             </ul>
     <li>Consent can be explicit (they tell you it's OK) or implicit (tell them you intend
         to add their name, and allow reasonable time for them to object or opt-out).
@@ -139,19 +148,6 @@
         (including people's names and details of show participation).
         As with copyright law, any legal action would likely cause Camdram to shut down
         permanently.
-    </ul>
-    <br />
-
-<h4>Show listings must be legal and reasonable</h4>
-    <ul>
-    <li>We need to keep Camdram as accessible and welcoming to all visitors as
-        possible, as well as preventing any legal action against the website.
-    <li>You must not use Camdram to incite hatred or prejudice.
-    <li>Images uploaded to Camdram must not be illegal, nor inappropriate for a general
-        audience.
-    <li>Content of show listings must not be gratuitously or needlessly obscene.
-        Explicit language is OK if justified by the show for artistic reasons; unnecessary
-        swearing in descriptions or role titles is not.
     </ul>
     <br />
 

--- a/app/Resources/views/static/user-guidelines.html.twig
+++ b/app/Resources/views/static/user-guidelines.html.twig
@@ -159,7 +159,7 @@
                 <li>Camdram's show listings, which are accessible to the general public
                     as well as search engines;
                 <li>Third-party websites that reuse our data.
-                    <!--that follow our <a href="">Acceptable Use Policy</a>.-->
+                    <!--(and follow our non-existent Acceptable Use Policy?)-->
             </ul>
     <li>Consent can be explicit (they tell you it's OK) or implicit (tell them you intend
         to add their name, and allow reasonable time for them to object or opt-out).

--- a/app/Resources/views/static/user-guidelines.html.twig
+++ b/app/Resources/views/static/user-guidelines.html.twig
@@ -11,11 +11,11 @@
     <h4>Summary</h4>
 
     <p>If you log in to Camdram, you agree to:</p>
-    <ol>
+    <ul>
     <li>Only create show listings that are genuine, accurate and appropriate;
     <li>Create and manage listings in accordance with English law, especially
         regarding copyright, plagiarism, and personal data privacy.
-    </ol>
+    </ul>
     <br />
     <p>
         Please read on; we've tried to keep this brief and clear.
@@ -158,8 +158,8 @@
             <ul>
                 <li>Camdram's show listings, which are accessible to the general public
                     as well as search engines;
-                <li>Third-party websites that follow our
-                    <a href="{{ path('acts_camdram_userguidelines') }}">Acceptable Use Policy</a>.                         <!-- TODO -->
+                <li>Third-party websites that reuse our data.
+                    <!--that follow our <a href="">Acceptable Use Policy</a>.-->
             </ul>
     <li>Consent can be explicit (they tell you it's OK) or implicit (tell them you intend
         to add their name, and allow reasonable time for them to object or opt-out).

--- a/app/Resources/views/static/user-guidelines.html.twig
+++ b/app/Resources/views/static/user-guidelines.html.twig
@@ -165,8 +165,6 @@
         to add their name, and allow reasonable time for them to object or opt-out).
     <li>Do not assume permission solely because the person is already listed on other
         shows on Camdram.
-    <li>You can remove or correct data on Camdram at any time by contacting either the
-        show's administrators or support@camdram.net.
     </ul>
     <br />
 

--- a/app/Resources/views/static/user-guidelines.html.twig
+++ b/app/Resources/views/static/user-guidelines.html.twig
@@ -1,10 +1,10 @@
 {% extends 'layout.html.twig' %}
 
-{% block title %}User Policy{% endblock %}
+{% block title %}User Guidelines{% endblock %}
 
 {% block body %}
 
-<h2>Camdram User Policy</h2>
+<h2>Camdram User Guidelines</h2>
 
 <h3>Summary</h3>
 
@@ -15,17 +15,17 @@
         and reasonably.
     </ol>
     <p>
-        Please read on for more information about these requirements; we've
-        tried to keep this brief and clear.
+        Please read on for more information; we've tried to keep this
+        brief and clear.
     </p>
 
 <h3>Definitions</h3>
 
-    <p>In this document:</p>
+    <p>In these Guidelines:</p>
     <ul>
     <li>words like &lsquo;us&rsquo; or &lsquo;we&rsquo; mean the volunteers who manage
         and administer Camdram, who can be contacted by emailing
-        <a href="mailto:support@camdram.net?Subject=User%20Policy">support@camdram.net</a>;
+        <a href="mailto:support@camdram.net?Subject=User%20Guidelines">support@camdram.net</a>;
 
     <li>words like &lsquo;Camdram&rsquo; or &lsquo;the website&rsquo; mean the website
         hosted at www.camdram.net and other subdomains of camdram.net;
@@ -45,16 +45,29 @@
         <a href="{{ path('acts_camdram_privacy') }}">Privacy Policy</a>.
     </p>
 
-<h3>Changes to this Policy</h3>
+<h3>Changes to the Guidelines</h3>
 
     <p>
-        We may change this User Policy at any time. The latest version will always be available
-        on this website. If we make any significant changes, we will make reasonable efforts to
-        inform users of the change, usually via email. If you continue to use Camdram, you
-        accept the latest version of the User Policy.
+        We may change the User Guidelines at any time. The applicable version
+        is always the one accessible on this website. If we make significant
+        changes, we will make reasonable efforts to tell users about the change,
+        usually via email. If you continue to use Camdram, you agree to follow
+        the latest version of the User Guidelines.
     </p>
 
-<h3>Respect copyright &amp; plagiarism law</h3>
+<h3>Enforcing the Guidelines</h3>
+
+    <p>
+        We will remove any content that we know or reasonably suspect does
+        not align with these Guidelines. We may suspend or ban users who
+        ignore the Guidelines deliberately or repeatedly. We will be
+        reasonable in how we apply these powers but final decisions will
+        rest with us alone.
+    </p>
+
+<h3>Guidelines in detail</h3>
+
+<h4>Respect copyright &amp; plagiarism law</h4>
 
     <ul>
     <li>We could be sued for hosting copyrighted or plagiarised content (images, text or other
@@ -66,8 +79,9 @@
         mean content can be used freely or without permission. You must assume you cannot use
         content until you know for sure you can.
     </ul>
+    <br />
 
-<h3>Show listings must be genuine and accurate</h3>
+<h4>Show listings must be genuine and accurate</h4>
 
     <ul>
     <li>Part of the purpose of Camdram is to be an accurate historical record.
@@ -99,12 +113,13 @@
             <li>Cast should be credited according to the script, libretto or other source
                 text, where applicable.
             <li>You should use standard role titles where possible for production team.
-                Humorous roles are fine provided they describe genuine participation
+            <li>Humorous roles are fine provided they describe genuine participation
                 (&lsquo;Technical Overlord&rsquo; is fine, for example).
             </ul>
     </ul>
+    <br />
 
-<h3>Respect personal data privacy</h3>
+<h4>Respect personal data privacy</h4>
 
     <ul>
     <li>If you wish to add someone's name as a participant (cast, crew or band member)
@@ -125,8 +140,9 @@
         As with copyright law, any legal action would likely cause Camdram to shut down
         permanently.
     </ul>
+    <br />
 
-<h3>Show listings must be legal and reasonable</h3>
+<h4>Show listings must be legal and reasonable</h4>
     <ul>
     <li>We need to keep Camdram as accessible and welcoming to all visitors as
         possible, as well as preventing any legal action against the website.
@@ -137,14 +153,6 @@
         Explicit language is OK if justified by the show for artistic reasons; unnecessary
         swearing in descriptions or role titles is not.
     </ul>
-
-<h3>Enforcing this policy</h3>
-
-    <p>
-        We will remove any content that we know or reasonably suspect does not align with
-        this Policy. We may suspend or ban users who ignore this Policy deliberately or
-        repeatedly. We will be reasonable in how we apply these powers but final decisions
-        will rest with us and us alone.
-    </p>
+    <br />
 
 {% endblock %}

--- a/app/Resources/views/static/user-guidelines.html.twig
+++ b/app/Resources/views/static/user-guidelines.html.twig
@@ -14,6 +14,7 @@
     <li>Create and manage listings in accordance with English law, especially
         regarding copyright, plagiarism, and personal data privacy.
     </ol>
+    <br />
     <p>
         Please read on for more information; we've tried to keep this
         brief and clear.
@@ -23,12 +24,12 @@
 
     <p>In these Guidelines:</p>
     <ul>
-    <li>words like &lsquo;us&rsquo; or &lsquo;we&rsquo; mean the volunteers who manage
-        and administer Camdram, who can be contacted by emailing
-        <a href="mailto:support@camdram.net?Subject=User%20Guidelines">support@camdram.net</a>;
-
     <li>words like &lsquo;Camdram&rsquo; or &lsquo;the website&rsquo; mean the website
         hosted at www.camdram.net and other subdomains of camdram.net;
+
+    <li>words like &lsquo;us&rsquo; or &lsquo;we&rsquo; mean the volunteers
+        who manage and administer Camdram
+        (<a href="{{ path('acts_camdram_contact_us') }}">contact us</a>);
 
     <li>words like &lsquo;you&rsquo; mean the people who use Camdram to list productions,
         roles, vacancies and adverts.
@@ -64,11 +65,16 @@
 
 <p><strong>Show listings must be genuine and accurate</strong></p>
 
+<p><strong>WHY?</strong>
+    Camdram is meant to be an accurate historical record, and a trustworthy
+    data source for other websites that reuse content from Camdram.
+</p>
+
     <ul>
-    <li>Part of the purpose of Camdram is to be an accurate historical record.
-    <li>Other third-party websites reuse content from Camdram.
-    <li>You must only create show listings for genuine productions or performances,
-        that are aligned with our <a href="{{ path('acts_camdram_userguidelines') }}">Suitability Guidelines</a>.             <!-- TODO -->
+    <li>You must only create show listings for genuine productions or
+        performances, that are aligned with our current
+        <a href="{{ path('acts_camdram_faq') }}#suitability">
+        suitability guidelines</a>.
     <li>It is absolutely OK to create listings for productions which have an element of
         uncertainty over whether they will be able to go ahead, for practical / logistic
         reasons (e.g. funding), provided there's a genuine desire and effort to make them
@@ -101,9 +107,13 @@
     <br />
 
 <p><strong>Show listings must be legal and reasonable</strong></p>
+
+<p><strong>WHY?</strong>
+    We want Camdram to be accessible and welcoming to all visitors.
+    Legal action would probably force Camdram to shut down permanently.
+</p>
+
     <ul>
-    <li>We need to keep Camdram as accessible and welcoming to all visitors as
-        possible, as well as preventing any legal action against the website.
     <li>You must not use Camdram to incite hatred or prejudice.
     <li>Images uploaded to Camdram must not be illegal, nor inappropriate for a general
         audience.
@@ -115,10 +125,13 @@
 
 <p><strong>Respect copyright &amp; plagiarism law</strong></p>
 
+<p><strong>WHY?</strong>
+    We could face legal action if Camdram hosts copyrighted or
+    plagiarised content (images, text or other formats).
+</p>
+
     <ul>
-    <li>We could be sued for hosting copyrighted or plagiarised content (images, text or other
-        formats). Any legal action would likely cause Camdram to shut down permanently.
-    <li>We rely on and trust you to ensure you have permission (or &lsquo;rights&rsquo;) to use
+    <li>You must ensure you have permission (or &lsquo;rights&rsquo;) to use
         images or descriptive text added to Camdram. You must include credits or citations where
         needed.
     <li>Absence of a copyright statement or mark (like &copy; or &trade;) does not automatically
@@ -129,13 +142,18 @@
 
 <p><strong>Respect personal data privacy</strong></p>
 
+<p><strong>WHY?</strong>
+    We could face legal action if Camdram doesn't comply with
+    laws regarding the use of personal data.
+</p>
+
     <ul>
     <li>If you wish to add someone's name as a participant (cast, crew or band member)
         in a show, you must ensure you have their consent for that information to appear in:
             <ul>
                 <li>Camdram's show listings, which are accessible to the general public
                     as well as search engines;
-                <li>Third party websites that follow our
+                <li>Third-party websites that follow our
                     <a href="{{ path('acts_camdram_userguidelines') }}">Acceptable Use Policy</a>.                         <!-- TODO -->
             </ul>
     <li>Consent can be explicit (they tell you it's OK) or implicit (tell them you intend
@@ -144,10 +162,6 @@
         shows on Camdram.
     <li>You can remove or correct data on Camdram at any time by contacting either the
         show's administrators or support@camdram.net.
-    <li>We are obliged to comply with privacy laws regarding the use of personal data
-        (including people's names and details of show participation).
-        As with copyright law, any legal action would likely cause Camdram to shut down
-        permanently.
     </ul>
     <br />
 

--- a/app/Resources/views/static/user-policy.html.twig
+++ b/app/Resources/views/static/user-policy.html.twig
@@ -1,0 +1,150 @@
+{% extends 'layout.html.twig' %}
+
+{% block title %}User Policy{% endblock %}
+
+{% block body %}
+
+<h2>Camdram User Policy</h2>
+
+<h3>Summary</h3>
+
+    <p>If you log in to Camdram, you agree to:</p>
+    <ol>
+    <li>Obey laws regarding copyright, plagiarism and personal data privacy;
+    <li>Only create genuine, accurate show listings, and describe them legally
+        and reasonably.
+    </ol>
+    <p>
+        Please read on for more information about these requirements; we've
+        tried to keep this brief and clear.
+    </p>
+
+<h3>Definitions</h3>
+
+    <p>In this document:</p>
+    <ul>
+    <li>words like &lsquo;us&rsquo; or &lsquo;we&rsquo; mean the volunteers who manage
+        and administer Camdram, who can be contacted by emailing
+        <a href="mailto:support@camdram.net?Subject=User%20Policy">support@camdram.net</a>;
+
+    <li>words like &lsquo;Camdram&rsquo; or &lsquo;the website&rsquo; mean the website
+        hosted at www.camdram.net and other subdomains of camdram.net;
+
+    <li>words like &lsquo;you&rsquo; mean the people who use Camdram to list productions,
+        roles, vacancies and adverts.
+    </ul>
+
+    <p>
+        Camdram is governed by English law. Whilst run for the benefit of the Cambridge
+        student amateur theatrical community, Camdram is officially unaffiliated with any
+        theatre or educational institution.
+    </p>
+
+    <p>
+        By using Camdram you also accept our
+        <a href="{{ path('acts_camdram_privacy') }}">Privacy Policy</a>.
+    </p>
+
+<h3>Changes to this Policy</h3>
+
+    <p>
+        We may change this User Policy at any time. The latest version will always be available
+        on this website. If we make any significant changes, we will make reasonable efforts to
+        inform users of the change, usually via email. If you continue to use Camdram, you
+        accept the latest version of the User Policy.
+    </p>
+
+<h3>Respect copyright &amp; plagiarism law</h3>
+
+    <ul>
+    <li>We could be sued for hosting copyrighted or plagiarised content (images, text or other
+        formats). Any legal action would likely cause Camdram to shut down permanently.
+    <li>We rely on and trust you to ensure you have permission (or &lsquo;rights&rsquo;) to use
+        images or descriptive text added to Camdram. You must include credits or citations where
+        needed.
+    <li>Absence of a copyright statement or mark (like &copy; or &trade;) does not automatically
+        mean content can be used freely or without permission. You must assume you cannot use
+        content until you know for sure you can.
+    </ul>
+
+<h3>Show listings must be genuine and accurate</h3>
+
+    <ul>
+    <li>Part of the purpose of Camdram is to be an accurate historical record.
+    <li>Other third-party websites reuse content from Camdram.
+    <li>You must only create show listings for genuine productions or performances,
+        that are aligned with our Suitability Guidelines (LINK).                                <!-- TODO -->
+    <li>It is absolutely OK to create listings for productions which have an element of
+        uncertainty over whether they will be able to go ahead, for practical / logistic
+        reasons (e.g. funding), provided there's a genuine desire and effort to make them
+        happen. If the production does not end up being performed or completed, you should
+        delete the listing as soon as reasonably possible.
+    <li>You must not create entirely fictitious listings, for any reason.
+    <li>Camdram is an English-language website. Listings should be predominantly in
+        English; foreign-language listing titles are fine, but general descriptions and
+        roles should be in English.
+    <li>If you can edit a show listing on Camdram, you are responsible for the
+        listing's content, regardless of whether others can also edit the listing.
+    <li>You must do your best to keep show details accurate, for example if performance
+        time or location is changed. This also includes information in show descriptions.
+    <li>Show listings do not need to be deadly serious. Humour is great, especially if
+        it fits the production. However, listings should always be grounded in fact.
+    <li>We want Camdram to be accessible, inclusive and welcoming to as wide an
+        audience as possible. You must not go out of your way to embed in-jokes in show
+        listings or otherwise make the listing inscrutable or incomprehensible to a
+        general audience.
+    <li>All people listed as having participated in a production (cast, band and
+        production team) must genuinely have participated.
+            <ul>
+            <li>Cast should be credited according to the script, libretto or other source
+                text, where applicable.
+            <li>You should use standard role titles where possible for production team.
+                Humorous roles are fine provided they describe genuine participation
+                (&lsquo;Technical Overlord&rsquo; is fine, for example).
+            </ul>
+    </ul>
+
+<h3>Respect personal data privacy</h3>
+
+    <ul>
+    <li>If you wish to add someone's name as a participant (cast, crew or band member)
+        in a show, you must ensure you have their consent for that information to appear in:
+            <ul>
+                <li>Camdram's show listings, which are accessible to the general public
+                    as well as search engines;
+                <li>Third party websites that follow our Acceptable Use Policy (LINK).          <!-- TODO -->
+            </ul>
+    <li>Consent can be explicit (they tell you it's OK) or implicit (tell them you intend
+        to add their name, and allow reasonable time for them to object or opt-out).
+    <li>Do not assume permission solely because the person is already listed on other
+        shows on Camdram.
+    <li>You can remove or correct data on Camdram at any time by contacting either the
+        show's administrators or support@camdram.net.
+    <li>We are obliged to comply with privacy laws regarding the use of personal data
+        (including people's names and details of show participation).
+        As with copyright law, any legal action would likely cause Camdram to shut down
+        permanently.
+    </ul>
+
+<h3>Show listings must be legal and reasonable</h3>
+    <ul>
+    <li>We need to keep Camdram as accessible and welcoming to all visitors as
+        possible, as well as preventing any legal action against the website.
+    <li>You must not use Camdram to incite hatred or prejudice.
+    <li>Images uploaded to Camdram must not be illegal, nor inappropriate for a general
+        audience.
+    <li>Content of show listings must not be gratuitously or needlessly obscene.
+        Explicit language is OK if justified by the show for artistic reasons; unnecessary
+        swearing in descriptions or role titles is not.
+    </ul>
+
+<h3>Enforcing this policy</h3>
+
+    <p>
+        We will remove any content that we know or reasonably suspect does not align with
+        this Policy. We may suspend or ban users who ignore this Policy deliberately or
+        repeatedly. We will be reasonable in how we apply these powers but final decisions
+        will rest with us and us alone.
+    </p>
+
+{% endblock %}

--- a/src/Acts/CamdramBundle/Resources/config/routing.yml
+++ b/src/Acts/CamdramBundle/Resources/config/routing.yml
@@ -23,6 +23,11 @@ acts_camdram_privacy:
     defaults:
         _controller: FrameworkBundle:Template:template
         template: 'static/privacy.html.twig'
+acts_camdram_userpolicy:
+    path: /user-policy
+    defaults:
+        _controller: FrameworkBundle:Template:template
+        template: 'static/user-policy.html.twig'
 acts_camdram_roles:
     type:     rest
     prefix:   /
@@ -42,7 +47,7 @@ acts_camdram_faq:
     defaults:
         _controller: FrameworkBundle:Template:template
         template: 'static/faq.html.twig'
-        
+
 camdram_annotation:
     resource: "@ActsCamdramBundle/Controller/"
     type:     annotation

--- a/src/Acts/CamdramBundle/Resources/config/routing.yml
+++ b/src/Acts/CamdramBundle/Resources/config/routing.yml
@@ -23,11 +23,11 @@ acts_camdram_privacy:
     defaults:
         _controller: FrameworkBundle:Template:template
         template: 'static/privacy.html.twig'
-acts_camdram_userpolicy:
-    path: /user-policy
+acts_camdram_userguidelines:
+    path: /user-guidelines
     defaults:
         _controller: FrameworkBundle:Template:template
-        template: 'static/user-policy.html.twig'
+        template: 'static/user-guidelines.html.twig'
 acts_camdram_roles:
     type:     rest
     prefix:   /

--- a/tests/Functional/SmokeTest.php
+++ b/tests/Functional/SmokeTest.php
@@ -11,7 +11,7 @@ class SmokeTest extends WebTestCase
         "/about",
         "/faq",
         "/privacy",
-        "/user-policy",
+        "/user-guidelines",
         "/contact-us",
         "/societies",
         "/venues",

--- a/tests/Functional/SmokeTest.php
+++ b/tests/Functional/SmokeTest.php
@@ -11,23 +11,24 @@ class SmokeTest extends WebTestCase
         "/about",
         "/faq",
         "/privacy",
+        "/user-policy",
         "/contact-us",
         "/societies",
         "/venues",
         "/people",
         "/auth/login",
     ];
-    
+
     /**
      * @var Symfony\Bundle\FrameworkBundle\Client
      */
     private $client;
-    
+
     public function setUp()
     {
         $this->client = self::createClient(array('environment' => 'test'));
     }
-    
+
     public function testSuccessful()
     {
         foreach ($this->URLS as $url) {
@@ -40,5 +41,5 @@ class SmokeTest extends WebTestCase
             $this->assertContains('</body>', $response->getContent(), "URL: $url");
         }
     }
-    
+
 }


### PR DESCRIPTION
* Brand new User Guidelines page, referenced from the footer on all pages; also linked when users log in or add a new show.
* Also includes significant rework to Privacy Policy, mainly because of the new UGs but also some general stylistic changes, etc. Some changes came from the discussion on #556, some from #171 (this PR potentially ticks off quite a few angles from that issue), and some just seemed sensible to me (trying to keep a logical separation between these documents, improve legal robustness etc). 

We all contributed to the draft UGs already, but please note they have evolved somewhat more in the process of creating an actual webpage. Please do review the wording again if you're at all invested in it! 

I'm totally OK if the suggested changes to the Privacy Policy create some debate; I'm not trying to unilaterally/undemocratically overhaul them. We can take debate to Gitter (or back to a Google Doc) if people want to - I thought I'd try to skip that step purely in the interests of making more rapid progress. 

The New Show page has also changed somewhat noticeably - beyond just linking to the UGs. I took the opportunity to _attempt to_ improve placement and formatting of guidance text, putting it closest to where it is relevant on the page. 

No hurry to merge this - whenever we get consensus. When we have merged, there are still some final tasks for #556 i.e. emailing all users.