### PR TITLE
Feature person tabs

### DIFF
--- a/app/DoctrineMigrations/Version20190520210628.php
+++ b/app/DoctrineMigrations/Version20190520210628.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20190520210628 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE acts_shows_people_link ADD tag VARCHAR(20) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE acts_shows_people_link DROP tag');
+    }
+}

--- a/app/Resources/views/person/admin-panel.html.twig
+++ b/app/Resources/views/person/admin-panel.html.twig
@@ -1,7 +1,8 @@
 <div class="admin-panel">
-    <h6 class="split-header">Person Administration: {{ person.name}}<span>ID: {{person.id}}</span></h6>
+    <h6 class="split-header"><span>Person Administration: <a href="{{ path('get_person', {identifier: person.slug}) }}">{{ person.name}}</a></span><span>ID: {{person.id}}</span></h6>
     <ul role="menubar">
         {{ include('navigation/nav-item.html.twig', {item: {id: 'edit_person', path: path('edit_person',{identifier:person.slug}), icon: 'pencil', text: 'Edit profile'} }) }}
+        {{ include('navigation/nav-item.html.twig', {item: {id: 'get_person_edit_roles', path: path('get_person_edit_roles', {identifier: person.slug}), icon: 'edit', text: 'Manage roles'} }) }}
         {% if is_granted('DELETE', person) %}
             {{ include('navigation/form-item.html.twig', {item: {id: 'delete_person',
                 path: path('delete_person', {identifier:person.slug}), method: 'DELETE', text: 'Delete this person', icon: 'eraser'},

--- a/app/Resources/views/person/current-shows.html.twig
+++ b/app/Resources/views/person/current-shows.html.twig
@@ -1,9 +1,10 @@
 {% if shows | length > 0 %}
     <h4>{{ person.name }} is currently involved with</h4>
+    <div>
     {% for show in shows %}
-        <div itemscope itemtype="http://schema.org/TheaterEvent">
-            {{ include('person/show-header.html.twig') }}
+        <div {{ include('person/show-header.html.twig') }}
             <p>{{ show.description | camdram_markdown }}</p>
         </div>
     {% endfor %}
+    </div>
 {% endif %}

--- a/app/Resources/views/person/edit-roles.html.twig
+++ b/app/Resources/views/person/edit-roles.html.twig
@@ -1,0 +1,150 @@
+{% extends 'layout.html.twig' %}
+
+{% block title %}Person - {{ person.name }} - Edit{% endblock %}
+
+{% block body %}
+
+{%- set tags = [] -%}
+{%- for role in roles -%}
+    {%- if role.tag and role.tag not in tags -%}
+        {%- set tags = tags|merge([role.tag]) -%}
+    {%- endif -%}
+{%- endfor -%}
+{#- Reversing twice converts sorted arrays such as { 1 => 'Alpha', 0 => 'Beta' }
+    to { 0 => 'Alpha', 1 => 'Beta' } so that json_encode correctly creates a JS array -#}
+{%- set tags = tags|sort|reverse|reverse -%}
+
+{{ include('person/admin-panel.html.twig') }}
+
+<h3>Edit Roles</h3>
+<p>By default your roles are all displayed at once, but can be sorted into cast, band, and prod team. If you have a large number of roles you might like to change how your roles are sorted by adding a tag to some or all of them.</p>
+
+<h4>Your tags</h4>
+<p>Create new tags here, then you can apply them to each role.</p>
+
+<div class="tag-container" data-tags-json="{{ tags | json_encode() }}">
+<span class="new-tag-generator"><input placeholder="New tag..."/><button type="button" class="small fa fa-plus-circle"></button></span>
+</div>
+<br>
+
+<h4>Your roles</h4>
+<table id="roles-table">
+<tr><th>Show name</th><th>Your role</th><th>Type</th><th style="min-width: 7em">Tag</th></tr>
+{%- for role in roles -%}
+<tr>
+<td>
+<a href="{{ path('get_show', { identifier: role.show.slug }) }}">{{ role.show.name }}</a>
+{%- if not role.show.authorised %} <abbr title="This show is not publicly visible yet" class="fa fa-eye-slash"></abbr>{%- endif -%}
+<span class="fa roles-status-icon"></span>
+</td>
+<td>{{ role.role }}</td><td>{{ role.type }}</td>
+<td><select data-role-id="{{ role.id }}">
+<option value="" {% if not role.tag %}selected="selected"{% endif %} style="color: grey">No tag</option>
+{%- for tag in tags -%}
+    <option value="{{ tag }}" {% if tag == role.tag %}selected="selected"{% endif %}>{{tag}}</option>
+{%- endfor -%}
+</select></td>
+</tr>
+{%- endfor -%}
+</table>
+
+<script>
+{#- begin-CSP-permitted-script -#}
+    var tagContainer = document.querySelector('.tag-container');
+    var newTagGenerator = document.querySelector('.new-tag-generator');
+    var tags = JSON.parse(tagContainer.dataset.tagsJson);
+
+    function saveState(selectBox) {
+        var role = selectBox.dataset.roleId;
+        var newtag = selectBox.selectedOptions[0].value;
+        var xhr = new XMLHttpRequest();
+        var icon = selectBox.parentNode.parentNode.querySelector('.roles-status-icon');
+        icon.classList.add('fa-spinner');
+        icon.classList.add('fa-spin');
+        icon.classList.remove('fa-exclamation-circle');
+        icon.title = 'Loading...';
+        xhr.addEventListener("load", function() {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                icon.classList.remove('fa-spinner');
+                icon.classList.remove('fa-spin');
+                icon.classList.remove('fa-exclamation-circle');
+                icon.title = '';
+            } else {
+                icon.classList.remove('fa-spinner');
+                icon.classList.remove('fa-spin');
+                icon.classList.add('fa-exclamation-circle');
+                icon.title = 'Unable to save changes (error ' + xhr.status + ')';
+            }
+        });
+        xhr.addEventListener("error", function() {
+            icon.classList.remove('fa-spinner');
+            icon.classList.remove('fa-spin');
+            icon.classList.add('fa-exclamation-circle');
+            icon.title = 'Unable to save changes';
+        });
+        xhr.open('PATCH', Routing.generate('patch_roles_settag'));
+        xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+        xhr.send('role=' + encodeURIComponent(role) + '&newtag=' + encodeURIComponent(newtag));
+    }
+
+    function deleteTag(e) {
+        var tagItem = e.target.parentNode;
+        for (var selectBox of document.querySelectorAll("#roles-table select")) {
+            if (selectBox.selectedOptions[0].value == tagItem.dataset.tagName) {
+                selectBox.selectedIndex = 0;
+                saveState(selectBox);
+            }
+            for (var option of selectBox.querySelectorAll('option')) {
+                if (option.value == tagItem.dataset.tagName) selectBox.removeChild(option);
+            }
+        }
+        tagItem.parentNode.removeChild(tagItem);
+        tags.splice(tags.indexOf(tagItem.dataset.tagName), 1);
+    }
+
+    function createTagItem(name) {
+        var tagItem = document.createElement('span');
+        tagItem.classList = 'tag';
+        tagItem.innerText = name;
+        tagItem.dataset.tagName = name;
+        var closeButton = document.createElement('button');
+        closeButton.classList = 'fa fa-times-circle text-button';
+        closeButton.addEventListener('click', deleteTag);
+        tagItem.insertBefore(closeButton, null);
+        tagContainer.insertBefore(tagItem, newTagGenerator);
+    }
+
+    function listNewTag(tagName) {
+        if (!tagName || tags.indexOf(tagName) >= 0) return;
+        tags.push(tagName);
+
+        createTagItem(tagName);
+        for (var selectBox of document.querySelectorAll("#roles-table select")) {
+            var newOption = document.createElement('option');
+            newOption.innerText = tagName;
+            newOption.value = tagName;
+            selectBox.insertAdjacentElement('beforeend', newOption);
+        }
+    };
+
+    newTagGenerator.querySelector('input').addEventListener('keydown', function(e) {
+        if (e.key !== 'Enter') return;
+        var newTagName = newTagGenerator.querySelector('input').value;
+        listNewTag(newTagName);
+    });
+    newTagGenerator.querySelector('button').addEventListener('click', function(e) {
+        var newTagName = newTagGenerator.querySelector('input').value;
+        listNewTag(newTagName);
+    });
+
+    for (var tag of tags) {
+        createTagItem(tag);
+    }
+    for (var selectBox of document.querySelectorAll("#roles-table select")) {
+        // Overcome effect of browser saving values.
+        selectBox.querySelector('option[selected]').selected = true;
+        selectBox.addEventListener('change', function(e) { saveState(e.target) });
+    }
+{#- end-CSP-permitted-script -#}
+</script>
+{% endblock %}

--- a/app/Resources/views/person/edit-roles.html.twig
+++ b/app/Resources/views/person/edit-roles.html.twig
@@ -28,8 +28,9 @@
 <br>
 
 <h4>Your roles</h4>
+<div style="overflow-x: auto; width: 100%">
 <table id="roles-table">
-<tr><th>Show name</th><th>Your role</th><th>Type</th><th style="min-width: 7em">Tag</th></tr>
+<tr><th>Show name</th><th>Your role</th><th class="hide-for-small">Type</th><th style="min-width: 7em">Tag</th></tr>
 {%- for role in roles -%}
 <tr>
 <td>
@@ -37,7 +38,7 @@
 {%- if not role.show.authorised %} <abbr title="This show is not publicly visible yet" class="fa fa-eye-slash"></abbr>{%- endif -%}
 <span class="fa roles-status-icon"></span>
 </td>
-<td>{{ role.role }}</td><td>{{ role.type }}</td>
+<td>{{ role.role }}<i class="show-for-small"> ({{ role.type }})</i></td><td class="hide-for-small">{{ role.type }}</td>
 <td><select data-role-id="{{ role.id }}">
 <option value="" {% if not role.tag %}selected="selected"{% endif %} style="color: grey">No tag</option>
 {%- for tag in tags -%}
@@ -47,6 +48,7 @@
 </tr>
 {%- endfor -%}
 </table>
+</div>
 
 <script>
 {#- begin-CSP-permitted-script -#}

--- a/app/Resources/views/person/edit-roles.html.twig
+++ b/app/Resources/views/person/edit-roles.html.twig
@@ -22,7 +22,7 @@
 <h4>Your tags</h4>
 <p>Create new tags here, then you can apply them to each role.</p>
 
-<div class="tag-container" data-tags-json="{{ tags | json_encode() }}">
+<div class="tag-container" data-tags-json="{{ tags | json_encode() }}" data-csrf-token="{{ csrf_token('patch_roles_settag') }}">
 <span class="new-tag-generator"><input placeholder="New tag..."/><button type="button" class="small fa fa-plus-circle"></button></span>
 </div>
 <br>
@@ -53,6 +53,7 @@
     var tagContainer = document.querySelector('.tag-container');
     var newTagGenerator = document.querySelector('.new-tag-generator');
     var tags = JSON.parse(tagContainer.dataset.tagsJson);
+    var csrfToken = tagContainer.dataset.csrfToken;
 
     function saveState(selectBox) {
         var role = selectBox.dataset.roleId;
@@ -84,7 +85,8 @@
         });
         xhr.open('PATCH', Routing.generate('patch_roles_settag'));
         xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-        xhr.send('role=' + encodeURIComponent(role) + '&newtag=' + encodeURIComponent(newtag));
+        xhr.send('role=' + encodeURIComponent(role) + '&newtag=' + encodeURIComponent(newtag) +
+            '&_token=' + encodeURIComponent(csrfToken));
     }
 
     function deleteTag(e) {

--- a/app/Resources/views/person/edit.html.twig
+++ b/app/Resources/views/person/edit.html.twig
@@ -4,6 +4,8 @@
 
 {% block body %}
 
+{{ include('person/admin-panel.html.twig', {person: form.vars.value}) }}
+
 <div class="row">
     <h3>Edit Person</h3>
     <form action="{{ path("put_person", {identifier: form.vars.value.slug, _method: 'put'}) }}" method="post" class="custom">

--- a/app/Resources/views/person/past-shows.html.twig
+++ b/app/Resources/views/person/past-shows.html.twig
@@ -2,8 +2,7 @@
     <h4>{{ person.name }} has been involved with</h4>
     <ul class="large-block-list">
     {% for show in shows %}
-        <li itemscope itemtype="http://schema.org/TheaterEvent">
-            {{ include('person/show-header.html.twig') }}
+        <li {{ include('person/show-header.html.twig') }}
         </li>
     {% endfor %}
     </ul>

--- a/app/Resources/views/person/show-header.html.twig
+++ b/app/Resources/views/person/show-header.html.twig
@@ -1,5 +1,11 @@
+{%- set tags = [] -%}
+{%- set roles = show.rolesByPerson(person) -%}
+{%- for role in roles -%}
+    {%- set tags = tags|merge([role.adjustedTag]) -%}
+{%- endfor -%}
+itemscope itemtype="http://schema.org/TheaterEvent" data-roletypes="{{ tags|json_encode()|e('html_attr') }}">
 <h5><a href="{{ url('get_show', {identifier : show.slug}) }}">{{ show.name }}</a> -
-    {% for role in show.rolesByPerson(person) %}
+    {% for role in roles %}
         {{ role.role -}}
         {% if not loop.last %},{% endif %}
     {% endfor %}

--- a/app/Resources/views/person/show.html.twig
+++ b/app/Resources/views/person/show.html.twig
@@ -66,6 +66,7 @@ $(function() {
 
     for (var tagName of Object.keys(tags).sort()) {
         aftertabs.insertAdjacentHTML('beforebegin', '<a href="#!" class="title"></a>');
+        aftertabs.previousElementSibling.href = '#!tab-' + tagName.replace(/[^A-Za-z0-9]/,'');
         aftertabs.previousElementSibling.innerText = tagName;
         aftertabs.previousElementSibling.addEventListener('click', (function(x) { return function(e) {
             for (var show of shows) show.setAttribute('hidden', 'hidden');
@@ -80,6 +81,9 @@ $(function() {
                 }
             }
         }})(tags[tagName]));
+        if (aftertabs.previousElementSibling.href == window.location.href) {
+            aftertabs.previousElementSibling.click();
+        }
     }
     aftertabs.parentNode.firstElementChild.addEventListener('click', function(e) {
         for (var show of shows) show.removeAttribute('hidden');

--- a/app/Resources/views/person/show.html.twig
+++ b/app/Resources/views/person/show.html.twig
@@ -27,14 +27,67 @@
     {% endif %}
 </div>
 
-{{ render(url('get_person_current_roles', {identifier: person.slug})) }}
-{{ render(url('get_person_upcoming_roles', {identifier: person.slug})) }}
-{{ render(url('get_person_past_roles', {identifier: person.slug})) }}
-
+<div class="tabbed-content">
+    <a href="#!" class="title active">All</a>
+    <div id="person-role-tabs"></div>
+    <div class="content">
+    {{ render(url('get_person_current_roles', {identifier: person.slug})) }}
+    {{ render(url('get_person_upcoming_roles', {identifier: person.slug})) }}
+    {{ render(url('get_person_past_roles', {identifier: person.slug})) }}
+    </div>
+</div>
 {% endblock %}
 
 {% block javascripts %}
 {% if person.norobots %}
 <meta name="robots" content="noindex" />
 {% endif %}
+<script>
+{#- begin-CSP-permitted-script -#}
+$(function() {
+    var shows = document.querySelectorAll('[data-roletypes]');
+    var aftertabs = document.querySelector('#person-role-tabs');
+    var tags = {};
+    for (var show of shows) {
+        for (var tag of JSON.parse(show.dataset.roletypes)) {
+            if (!tags[tag]) tags[tag] = [];
+            tags[tag].push(show);
+        }
+    }
+
+    if (Object.keys(tags).length <= 1) {
+        // Swap out .tabbed-content for its .content changed to a regular div.
+        var tabbedcontent = document.querySelector('.tabbed-content');
+        var content = tabbedcontent.querySelector('.content');
+        tabbedcontent.insertAdjacentElement('beforebegin', content);
+        tabbedcontent.parentNode.removeChild(tabbedcontent);
+        content.className = '';
+    }
+
+    for (var tagName of Object.keys(tags).sort()) {
+        aftertabs.insertAdjacentHTML('beforebegin', '<a href="#!" class="title"></a>');
+        aftertabs.previousElementSibling.innerText = tagName;
+        aftertabs.previousElementSibling.addEventListener('click', (function(x) { return function(e) {
+            for (var show of shows) show.setAttribute('hidden', 'hidden');
+            for (var show of x)     show.removeAttribute('hidden');
+            e.target.parentNode.querySelector('.active').classList.remove('active');
+            e.target.classList.add('active');
+            for (var heading of document.querySelectorAll('.content h4')) {
+                if (heading.nextElementSibling.querySelector('[itemtype*="TheaterEvent"]:not([hidden])')) {
+                    heading.removeAttribute('hidden');
+                } else {
+                    heading.setAttribute('hidden', 'hidden');
+                }
+            }
+        }})(tags[tagName]));
+    }
+    aftertabs.parentNode.firstElementChild.addEventListener('click', function(e) {
+        for (var show of shows) show.removeAttribute('hidden');
+        for (var heading of document.querySelectorAll('.content h4')) heading.removeAttribute('hidden');
+        e.target.parentNode.querySelector('.active').classList.remove('active');
+        e.target.classList.add('active');
+    });
+});
+{#- end-CSP-permitted-script -#}
+</script>
 {% endblock %}

--- a/app/Resources/views/person/upcoming-shows.html.twig
+++ b/app/Resources/views/person/upcoming-shows.html.twig
@@ -2,8 +2,7 @@
     <h4>{{ person.name }} is preparing for</h4>
     <ul class="large-block-list">
     {% for show in shows %}
-        <li itemscope itemtype="http://schema.org/TheaterEvent">
-            {{ include('person/show-header.html.twig') }}
+        <li {{ include('person/show-header.html.twig') }}
             <p>{{ show.description | truncate(200) }}</p>
         </li>
     {% endfor %}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -174,7 +174,7 @@ stof_doctrine_extensions:
             loggable: true
 
 fos_js_routing:
-    routes_to_expose: [ "get_[a-z]+", 'acts_camdram_.*', 'patch_roles_reorder', 'search_entity' ]
+    routes_to_expose: [ "get_[a-z]+", 'acts_camdram_.*', 'patch_roles_.*', 'search_entity' ]
 
 ewz_recaptcha:
     public_key: "%recaptcha_site_key%"

--- a/assets/scss/entities.scss
+++ b/assets/scss/entities.scss
@@ -179,3 +179,11 @@
     margin: 0.5em;
   }
 }
+
+.tag-container .tag {
+    background: lighten($orange, 35%);
+    padding: 0.4em 0.5em;
+    margin: 0.5em;
+    border: 1px solid $orange;
+    button { padding-left: 0.5em; }
+}

--- a/assets/scss/framework.scss
+++ b/assets/scss/framework.scss
@@ -368,6 +368,17 @@ nav.sidenav > a.active {
   border-style: none none solid none;
   background: #ddd;
   color: #111;
+  outline: none;
+  position: relative;
+  &:focus::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    background: #bbb;
+    height: 3px;
+  }
 }
 .tabbed-content .title.active {
   border-style: solid solid none solid;

--- a/src/Acts/CamdramBundle/Controller/PersonController.php
+++ b/src/Acts/CamdramBundle/Controller/PersonController.php
@@ -204,6 +204,27 @@ class PersonController extends AbstractRestController
     }
 
     /**
+     * @Rest\Get("/people/{identifier}/edit-roles", requirements={"_format"="html"})
+     */
+    public function getEditRolesAction($identifier)
+    {
+        $person = $this->getEntity($identifier);
+        $this->get('camdram.security.acl.helper')->ensureGranted('EDIT', $person);
+
+        $roles = $this->getDoctrine()->getManager()->createQuery(
+            'SELECT r, s FROM ActsCamdramBundle:Role r JOIN r.show s WHERE r.person = :p ORDER BY s.id')
+            ->setParameter('p', $person)->getResult();
+        $roles = array_filter($roles, function($r) {
+            return $this->get('camdram.security.acl.helper')->isGranted('VIEW', $r->getShow());
+        });
+
+        return $this->render('person/edit-roles.html.twig', array(
+            'person' => $person,
+            'roles' => $roles
+        ));
+    }
+
+    /**
      * @param $identifier
      * @param $request Request
      *

--- a/src/Acts/CamdramBundle/Controller/RoleController.php
+++ b/src/Acts/CamdramBundle/Controller/RoleController.php
@@ -6,6 +6,7 @@ use Acts\CamdramBundle\Entity\Role;
 use Acts\CamdramSecurityBundle\Security\Acl\Helper;
 use FOS\RestBundle\Controller\AbstractFOSRestController;
 use FOS\RestBundle\Controller\Annotations as Rest;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -46,10 +47,15 @@ class RoleController extends AbstractFOSRestController
      * Required params:
      *    role,   int (role id)
      *    newtag, string. (If blank, interpret as null)
+     *    _token  CSRF token
      * @Rest\Patch("/roles/settag", name="patch_roles_settag")
      */
     public function patchRolesSetTagAction(Request $request, Helper $_helper): Response
     {
+        if (!$this->isCsrfTokenValid('patch_roles_settag', $request->request->get('_token'))) {
+            throw new BadRequestHttpException('Invalid CSRF token');
+        }
+
         $em     = $this->getDoctrine()->getManager();
         $repo   = $em->getRepository('ActsCamdramBundle:Role');
         $id     = $request->request->get('role');

--- a/src/Acts/CamdramBundle/Controller/RoleController.php
+++ b/src/Acts/CamdramBundle/Controller/RoleController.php
@@ -18,11 +18,9 @@ class RoleController extends AbstractFOSRestController
      *
      * Reorder the display ordering for the array of Roles identified by their ID.
      *
-     * @param Request $request
      * @Rest\Patch("/roles/reorder", name="patch_roles_reorder")
-     * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function patchRolesReorderAction(Request $request, Helper $_helper)
+    public function patchRolesReorderAction(Request $request, Helper $_helper): Response
     {
         $em = $this->getDoctrine()->getManager();
         $repo = $em->getRepository('ActsCamdramBundle:Role');
@@ -41,5 +39,29 @@ class RoleController extends AbstractFOSRestController
         $response = new Response();
         $response->setStatusCode(204); // Success no content
         return $response;
+    }
+
+    /**
+     * Allow the person named in a role to set a tag on it
+     * Required params:
+     *    role,   int (role id)
+     *    newtag, string. (If blank, interpret as null)
+     * @Rest\Patch("/roles/settag", name="patch_roles_settag")
+     */
+    public function patchRolesSetTagAction(Request $request, Helper $_helper): Response
+    {
+        $em     = $this->getDoctrine()->getManager();
+        $repo   = $em->getRepository('ActsCamdramBundle:Role');
+        $id     = $request->request->get('role');
+        $newtag = trim($request->request->get('newtag'));
+        $role   = $repo->findOneById($id);
+
+        if (!$role) return new Response('role not found', 404);
+
+        $_helper->ensureGranted('EDIT', $role->getPerson());
+        $role->setTag(empty($newtag) ? NULL : $newtag);
+        $em->flush();
+        $em->clear();
+        return new Response('', 204); // Success no content
     }
 }

--- a/src/Acts/CamdramBundle/Entity/Role.php
+++ b/src/Acts/CamdramBundle/Entity/Role.php
@@ -89,6 +89,12 @@ class Role
     private $person;
 
     /**
+     * @ORM\Column(name="tag", type="string", length=20, nullable=true)
+     * @Gedmo\Versioned
+     */
+    private $tag;
+
+    /**
      * Get id
      *
      * @return int
@@ -240,6 +246,23 @@ class Role
     public function getPerson()
     {
         return $this->person;
+    }
+
+    public function setTag(?string $tag): self
+    {
+        $this->tag = $tag;
+
+        return $this;
+    }
+    public function getTag(): ?string
+    {
+        return $this->tag;
+    }
+    public function getAdjustedTag(): string
+    {
+        return $this->tag ?? [
+            'cast' => 'Acting', 'band' => 'Band', 'prod' => 'Crew'
+        ][$this->type];
     }
 
     /**

--- a/src/Acts/CamdramBundle/Entity/Role.php
+++ b/src/Acts/CamdramBundle/Entity/Role.php
@@ -90,6 +90,8 @@ class Role
 
     /**
      * @ORM\Column(name="tag", type="string", length=20, nullable=true)
+     * @Serializer\Expose()
+     * @Serializer\XmlElement(cdata=false)
      * @Gedmo\Versioned
      */
     private $tag;


### PR DESCRIPTION
A solution to overcrowded person pages. People whose roles can be split into multiple tabs have those tabs appear on their page. By default, roles are categorized into prod/band/crew, but users can override these choices by tagging each role with a string.

Fixes #660.