### PR TITLE
Vacancies reskin - make vacancies less blocky

### DIFF
--- a/assets/scss/entities.scss
+++ b/assets/scss/entities.scss
@@ -1,24 +1,41 @@
 @import "./vars.scss";
 
 #entity-header {
-  @include panel(#f2f2f2);
+    @include panel(#f2f2f2);
 }
 
 .vacancies-panel {
-  @include panel(rgb(250, 237, 220), 1em 1em 1em);
-  border-radius:7px;
+    @include panel(rgb(250, 237, 220), 1em 1em 1em);
+    border-radius: 7px;
 
-  &.hidden {
-    background: rgb(240, 240, 240);
-  }
+    &.hidden {
+        background: rgb(240, 240, 240);
+    }
+
+    hr {
+        border-color: var(--custom-color, $orange);
+        margin-left: auto;
+        margin-right: auto;
+        @media (min-width: $width-small) {
+            max-width: 40em;
+        }
+    }
 }
 
 .vacancies-show-panel {
-  background: rgb(242, 242, 242);
-  border: solid rgb(255, 140, 0);
-  border-width: 8px 1px 1px;
-  padding: 0.5em;
-  margin-bottom:0.5em;
+    padding: 0.5em 0;
+    margin-bottom: 0.5em;
+    border: solid var(--custom-color, $orange);
+    border-width: 1px 0;
+
+    @media (min-width: $width-small) {
+        background: white;
+        border-width: 8px 1px 1px;
+        padding: 0.5em;
+        float: right;
+        margin-left: 1em;
+        width: 30em;
+    }
 }
 
 

--- a/src/Acts/CamdramBundle/Entity/Performance.php
+++ b/src/Acts/CamdramBundle/Entity/Performance.php
@@ -104,14 +104,19 @@ class Performance implements EventInterface
         $startAt = clone $this->getStartAt();
         $startAt->setTimezone(new \DateTimeZone("Europe/London"));
 
-        $str = $startAt->format('H:i');
-
-        $str .= ', ' . $startAt->format('D jS F Y');
-        if ($this->isRepeating()) {
-            $str .= ' - '.$this->getRepeatUntil()->format('D jS F Y');
+        if (!$this->isRepeating()) {
+            return $startAt->format('H:i') . ', ' . $startAt->format('D j F Y');
         }
 
-        return $str;
+        $repeatUntil = $this->getRepeatUntil();
+        $str = '–' . $repeatUntil->format('D j F Y');
+        if ($startAt->format('F Y') === $repeatUntil->format('F Y')) {
+            return $startAt->format('D j') . $str;
+        }
+        if ($startAt->format('Y') === $repeatUntil->format('Y')) {
+            return $startAt->format('D j F') . $str;
+        }
+        return $startAt->format('D j F Y') . $str;
     }
 
     /**

--- a/src/Acts/CamdramBundle/Entity/Performance.php
+++ b/src/Acts/CamdramBundle/Entity/Performance.php
@@ -105,18 +105,18 @@ class Performance implements EventInterface
         $startAt->setTimezone(new \DateTimeZone("Europe/London"));
 
         if (!$this->isRepeating()) {
-            return $startAt->format('H:i') . ', ' . $startAt->format('D j F Y');
+            return $startAt->format('H:i, D jS F Y');
         }
 
         $repeatUntil = $this->getRepeatUntil();
-        $str = '–' . $repeatUntil->format('D j F Y');
+        $str = ' – ' . $repeatUntil->format('D jS F Y');
         if ($startAt->format('F Y') === $repeatUntil->format('F Y')) {
-            return $startAt->format('D j') . $str;
+            return $startAt->format('H:i, D jS') . $str;
         }
         if ($startAt->format('Y') === $repeatUntil->format('Y')) {
-            return $startAt->format('D j F') . $str;
+            return $startAt->format('H:i, D jS F') . $str;
         }
-        return $startAt->format('D j F Y') . $str;
+        return $startAt->format('H:i, D jS F Y') . $str;
     }
 
     /**

--- a/templates/advert/index.html.twig
+++ b/templates/advert/index.html.twig
@@ -8,8 +8,8 @@
     </div>
 
     {%- for a in adverts -%}
-        <div class="vacancies-panel">
-            <h5>{{ link_entity(a) }}</h5>
+        <div class="vacancies-panel row">
+            <h5>{{ link_entity(a, {innerhtml: (a.name|e) ~ '<i style="font-weight:normal"> – read more...</i>'}) }}</h5>
             {% if a.show %}
             <div class="vacancies-show-panel">
                 {%- include 'show/advert_header.html.twig' with {'show': a.show} -%}
@@ -36,7 +36,8 @@
             {%- endfor -%}
             </ul>
             <p></p>
-            <p>Contact {{ a.contactDetails|detect_links }} before {{a.expiresAt | date('jS M Y H:i')}} for more details.</p>
+            <p>For more details, read the {{ link_entity(a, {innertext: 'full advert'}) }} or contact {{
+                a.contactDetails|detect_links }} before {{a.expiresAt | date('jS M Y H:i')}}.</p>
         </div>
     {%- else -%}
         <p>There are currently no advertisements listed – please check again later.</p>

--- a/templates/advert/view.html.twig
+++ b/templates/advert/view.html.twig
@@ -2,6 +2,14 @@
 
 {% block title %}Advert: {{ advert.name }}{% endblock %}
 
+{% set entity = advert.show ?? advert.society ?? advert.venue %}
+{% if entity and entity.themeColor %}
+    {% set colors = wcag_colors(entity.themeColor) %}
+    {% set body_attribs_raw = ' style="--custom-color: '  ~ colors['raw'] ~
+                                    '; --color-text: ' ~ colors['smalltext'] ~ ';"' ~
+                              ' class="entity-has-theme-color"' %}
+{% endif %}
+
 {# Facebook open graph markup #}
 {% block opengraph %}
     <meta property="og:url" content="{{ url('get_advert', {identifier: advert.id}) }}" />
@@ -14,7 +22,7 @@
         {{ render(admin_panel(advert)) }}
     {% endif %}
 
-    <div class="vacancies-panel">
+    <div class="vacancies-panel row">
         <h4>{{ advert.name }}</h4>
         {% if advert.show %}
         <div class="vacancies-show-panel">
@@ -41,19 +49,17 @@
             <li>{{ audition.dateString }}, {{ audition.location }}</li>
         {%- endfor -%}
         </ul>
+        <p>{{ advert.body | camdram_markdown | annotate_positions(advert.positions) }}</p>
+
+        <hr>
+
         <p>Contact {{ advert.contactDetails | detect_links }} before {{advert.expiresAt | date('jS M Y H:i')}} for more details.</p>
     </div>
 
-    <hr/>
-
     {% if advert.auditions | length > 0 %}
     {{ render_diary(diary) }}
-    <hr/>
     {% endif%}
 
-    <p>{{ advert.body | camdram_markdown | annotate_positions(advert.positions) }}</p>
-
-    <hr/>
     <p class="text-right"><em>
         Created at {{ advert.createdAt | date('jS M Y H:i') }}<br />
         Last updated at {{ advert.updatedAt | date('jS M Y H:i') }}

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -39,7 +39,7 @@
                            {%- elseif week.startAt == current_week.endAt -%}
                                Next week
                            {%- else -%}
-                               {{ week.startAt|date('j&\\nb\\sp;M')|raw }}–<wbr>
+                               {{ week.startAt|date('j&#160;M')|raw }}–<wbr>
                                {{- week.endAt|date_modify("-1 day")|date('j&\\nb\\sp;M')|raw }}
                            {%- endif -%}
                        </span>

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -40,7 +40,7 @@
                                Next week
                            {%- else -%}
                                {{ week.startAt|date('j&#160;M')|raw }}–<wbr>
-                               {{- week.endAt|date_modify("-1 day")|date('j&\\nb\\sp;M')|raw }}
+                               {{- week.endAt|date_modify("-1 day")|date('j&#160;M')|raw }}
                            {%- endif -%}
                        </span>
                    </a>

--- a/templates/show/show.html.twig
+++ b/templates/show/show.html.twig
@@ -108,14 +108,15 @@
 <h5>Get involved with <em>{{ show.name }}</em>:</h5>
     {% for advert in show.activeAdverts %}
         <div class="vacancies-panel">
-            <h5>{{ link_entity(advert) }}</h5>
+            <h5>{{ link_entity(advert, {innerhtml: (advert.name|e) ~ '<i style="font-weight:normal"> – read more...</i>'}) }}</h5>
             <p>{{ advert.summary | annotate_positions(advert.positions) }}</p>
             <ul class="prose-list">
             {%- for audition in advert.auditions -%}
                 <li>{{ audition.dateString }}, {{ audition.location }}</li>
             {%- endfor -%}
             </ul>
-            <p>Contact {{ advert.contactDetails | detect_links }} before {{advert.expiresAt | date('jS M Y H:i')}} for more details.</p>
+            <p>For more details, read the {{ link_entity(advert, {innertext: 'full advert'}) }} or contact {{
+                advert.contactDetails | detect_links }} before {{advert.expiresAt | date('jS M Y H:i')}}.</p>
         </div>
     {% endfor %}
 {%- endif -%}

--- a/tests/CamdramBundle/Controller/DiaryControllerTest.php
+++ b/tests/CamdramBundle/Controller/DiaryControllerTest.php
@@ -96,7 +96,7 @@ class DiaryControllerTest extends RestTestCase
                     '_links' => [
                         'show' => '/shows/2000-test-show-1',
                     ],
-                    'date_string' => '20:30, Mon 3rd July 2000 - Thu 6th July 2000',
+                    'date_string' => '20:30, Mon 3rd – Thu 6th July 2000',
                     'start_at' => '2000-07-03T19:30:00+00:00',
                     'repeat_until' => '2000-07-06',
                 ],
@@ -140,7 +140,7 @@ class DiaryControllerTest extends RestTestCase
                     '_links' => [
                         'show' => '/shows/2000-test-show',
                     ],
-                    'date_string' => '20:30, Sun 25th June 2000 - Mon 26th June 2000',
+                    'date_string' => '20:30, Sun 25th – Mon 26th June 2000',
                     'start_at' => '2000-06-25T19:30:00+00:00',
                     'repeat_until' => '2000-06-26',
                 ],
@@ -165,7 +165,7 @@ class DiaryControllerTest extends RestTestCase
                     '_links' => [
                         'show' => '/shows/2000-test-show',
                     ],
-                    'date_string' => '20:30, Fri 2nd June 2000 - Thu 8th June 2000',
+                    'date_string' => '20:30, Fri 2nd – Thu 8th June 2000',
                     'start_at' => '2000-06-02T19:30:00+00:00',
                     'repeat_until' => '2000-06-08',
                 ],
@@ -201,7 +201,7 @@ class DiaryControllerTest extends RestTestCase
                     '_links' => [
                         'show' => '/shows/2000-test-show',
                     ],
-                    'date_string' => '20:30, Sun 18th June 2000 - Mon 19th June 2000',
+                    'date_string' => '20:30, Sun 18th – Mon 19th June 2000',
                     'start_at' => '2000-06-18T19:30:00+00:00',
                     'repeat_until' => '2000-06-19',
                 ],


### PR DESCRIPTION
Makes the appearance of vacancies less blocky and respects the show's (or organization's) theme colour when viewing an advert alone.

![Screen Shot 2022-02-24 at 22 21 36](https://user-images.githubusercontent.com/5357642/155617290-95c24545-15e2-4baa-8c40-0f69e91076b3.png)
![Screen Shot 2022-02-24 at 22 22 10](https://user-images.githubusercontent.com/5357642/155617368-dda6acbd-f4e9-4aa6-84c6-e1fc0059edf8.png)
