### PR TITLE
Remove rate-limiting

### DIFF
--- a/src/Acts/CamdramApiBundle/EventListener/KernelEventListener.php
+++ b/src/Acts/CamdramApiBundle/EventListener/KernelEventListener.php
@@ -58,21 +58,5 @@ class KernelEventListener
         if (substr($event->getRequest()->headers->get('Authorization'), 0, 6) == 'Bearer') {
             $authed = true;
         }
-
-        // If $authed is still false by now, then any API requests must be
-        // unauthenticated. Make the user's life generally a bit unpleasant.
-        if (!$authed && getenv("SYMFONY_ENV") !== 'test') {
-            $format = $event->getRequest()->getRequestFormat();
-            if ($format == 'json' || $format == 'xml') {
-                if (rand(1, 100) > 66) {
-                    $response = new Response();
-                    $response->setStatusCode(Response::HTTP_UNAUTHORIZED);
-                    $response->setContent("Unauthenticated API requests have a 1-in-3 chance of returning an HTTP 401 error. You should use an API key to avoid this.");
-                    $event->setResponse($response);
-                } else {
-                    sleep(12);
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
We have been seeing issues around performance and search for some time. A `sleep(12)` is a very blunt instrument for rate-limiting and seems likely to be the cause.

Fixes #2166, probably fixes #2313.