### PR TITLE
update links to replace development.camdram.net to www.camdram.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Camdram is an [open source](http://opensource.org/docs/osd) project developed by
 
 The steps required to set up a development checkout of Camdram are detailed below. For the sake of brevity, these instructions assume that the reader is familiar with a number of technologies, such as developing on a Linux based platform, using Git and GitHub.
 
-New releases are made on the `master` branch every so often using the GitHub interface. This automatically generates a changelog and pushes the new release into production at https://www.camdram.net/. The latest changes can be seen at https://development.camdram.net/ which always reflects the `HEAD` state of this repository.
+New releases are made on the `master` branch every so often using the GitHub interface. This automatically generates a changelog and pushes the new release into production at https://www.camdram.net/. The latest changes can be seen [here](https://www.camdram.net/development/) which always reflects the `HEAD` state of this repository.
 
 If you encounter any problems with the instructions below, please [create a GitHub issue]( https://github.com/camdram/camdram/issues/new) or send an e-mail to support@camdram.net. We also have a [live chat hosted on Gitter](https://gitter.im/camdram/development) which you can use to quickly and informally get in touch with the development team.
 

--- a/src/Acts/CamdramAdminBundle/Command/DownloadAssetsCommand.php
+++ b/src/Acts/CamdramAdminBundle/Command/DownloadAssetsCommand.php
@@ -42,7 +42,7 @@ class DownloadAssetsCommand extends Command
     }
 
     protected static $defaultName = 'camdram:assets:download';
-    private const defaultDomain = 'https://development.camdram.net';
+    private const defaultDomain = 'https://www.camdram.net';
     private const outputDirectory = __DIR__.'/../../../../web/';
 
     protected function configure(): void

--- a/src/Acts/CamdramAdminBundle/Composer/ScriptHandler.php
+++ b/src/Acts/CamdramAdminBundle/Composer/ScriptHandler.php
@@ -51,7 +51,7 @@ dedicated MySQL database instead.
 Visit https://github.com/camdram/camdram/wiki/Setting-up-a-MySQL-database to find out more
 
 <options=bold;fg=yellow>Javascript/CSS</>
-Minified assets have been downloaded from https://development.camdram.net/.
+Minified assets have been downloaded from https://www.camdram.net/.
 If you are planning on doing frontend development you will need to configure the Webpack toolchain.
 Visit https://github.com/camdram/camdram/wiki/Webpack-setup-guide to find out more
 


### PR DESCRIPTION
As development.camdram.net is no longer used to host relevent resources when initialising the codebase, getting the codebase to run locally requires changing this to the regular camdram website. This change reflects this, by replacing all instances of development.camdram.net to it's updated location.